### PR TITLE
New example: 'gmtime'

### DIFF
--- a/examples/06-gmtime/dune
+++ b/examples/06-gmtime/dune
@@ -1,0 +1,4 @@
+(executable
+  (name main)
+  (libraries unix)
+  (foreign_stubs (language c) (names main)))

--- a/examples/06-gmtime/main.c
+++ b/examples/06-gmtime/main.c
@@ -1,0 +1,30 @@
+#include <time.h>
+#define CAML_NAME_SPACE
+#include <caml/mlvalues.h>
+#include <caml/alloc.h>
+#include <caml/memory.h>
+
+value caml_gmtime(value t) {
+  CAMLparam1(t);
+  CAMLlocal1(result);
+  time_t timer;
+  struct tm *tm;
+
+  timer  = (time_t) Double_val(t);
+  tm     = gmtime(&timer);
+
+  result = caml_alloc(9, 0);
+
+  Store_field(result, 0, Val_int (tm->tm_sec  ));
+  Store_field(result, 1, Val_int (tm->tm_min  ));
+  Store_field(result, 2, Val_int (tm->tm_hour ));
+  Store_field(result, 3, Val_int (tm->tm_mday ));
+  Store_field(result, 4, Val_int (tm->tm_mon  ));
+  Store_field(result, 5, Val_int (tm->tm_year ));
+  Store_field(result, 6, Val_int (tm->tm_wday ));
+  Store_field(result, 7, Val_int (tm->tm_yday ));
+  Store_field(result, 8, Val_bool(tm->tm_isdst));
+
+  CAMLreturn(result);
+}
+

--- a/examples/06-gmtime/main.ml
+++ b/examples/06-gmtime/main.ml
@@ -1,0 +1,12 @@
+external gmtime  : float -> Unix.tm = "caml_gmtime"
+
+let () =
+  let my_res : Unix.tm = gmtime (Unix.time ()) in
+  Format.printf "Custom gmtime : %d/%d/%d %d:%d:%d\n"
+  my_res.tm_year my_res.tm_mon my_res.tm_mday
+  my_res.tm_hour my_res.tm_min my_res.tm_sec;
+
+  let res : Unix.tm = Unix.gmtime (Unix.time ()) in
+  Format.printf "Unix.gmtime   : %d/%d/%d %d:%d:%d\n"
+  res.tm_year res.tm_mon res.tm_mday
+  res.tm_hour res.tm_min res.tm_sec

--- a/theories/c_interface/notation.v
+++ b/theories/c_interface/notation.v
@@ -12,6 +12,6 @@ Coercion LitLoc : loc >-> base_lit.
    direction we would want. So we keep this global for now, and use #C whenever
    we need to be explicit. *)
 Notation "# l" := (LitV l%Z%CV%stdpp) (at level 8, format "# l").
-Notation "#C l" := (LitV l%Z%CV%stdpp) (at level 8, format "#C l").
+Notation "#C l" := (LitV l%Z%CV%stdpp) (at level 8, format "#C  l").
 
 Notation "& f" := (LitV (LitFunPtr f)) (at level 8, format "& f").

--- a/theories/c_interop/notation.v
+++ b/theories/c_interop/notation.v
@@ -14,9 +14,9 @@ Notation "'CAMLlocal:' x 'in' e2" := (CAMLlocal x%string e2%CE)
 Notation "'Field' '(' x ',' y ')'" := (call: &"readfield" with (x%CE, y%CE))%CE
   (at level 70, x, y at level 69,
   format "'Field' '(' x ','  '/' y ')'") : c_expr_scope.
-Notation "'Store_field' '(' '&' 'Field' '(' x ',' y ')' ',' z ')'" := (call: &"modify" with (x%CE, y%CE, z%CE))%CE
+Notation "'Store_field' '(' x ',' y ',' z ')'" := (call: &"modify" with (x%CE, y%CE, z%CE))%CE
   (at level 70, x, y, z at level 69,
-  format "'Store_field' '(' '&' 'Field' '(' x ','  y ')' ','  '/' z ')'") : c_expr_scope.
+  format "'Store_field' '(' x ','  y ','  z ')'") : c_expr_scope.
 
 Notation "'Int_val' '(' x ')'" := (call: &"val2int" with (x%CE))%CE
   (at level 70, x at level 69,
@@ -36,7 +36,7 @@ Notation "'caml_alloc' '(' len ',' tag ')'" := (call: &"alloc" with (tag%CE, len
   (at level 70, len, tag at level 69,
   format "'caml_alloc' '(' len ','  tag ')'") : c_expr_scope.
 Notation "'caml_alloc_custom' '(' ')'" := (call: &"alloc_foreign" with ( ))%CE
-  (at level 70, 
+  (at level 70,
   format "'caml_alloc_custom' '(' ')'") : c_expr_scope.
 (* XXX maybe make this list-based? *)
 Definition CAMLunregister1 ek := (call: &"unregisterroot" with ( ek ) ;; free (ek%CE, #1))%CE.

--- a/theories/c_lang/derived_laws.v
+++ b/theories/c_lang/derived_laws.v
@@ -30,7 +30,7 @@ Implicit Types sz off : nat.
 Lemma wp_Malloc s E n :
   (0 < n)%Z →
   {{{ True }}} Malloc (Val $ LitV $ LitInt $ n) @ s; E
-  {{{ l, RET LitV (LitLoc l); l ↦C∗ replicate (Z.to_nat n) None }}}.
+  {{{ l, RET LitV (LitLoc l); l I↦C∗ replicate (Z.to_nat n) None }}}.
 Proof.
   iIntros (Hzs Φ) "_ HΦ". iApply wp_Malloc_seq; [done..|]. iModIntro.
   iIntros (l) "Hlm". iApply "HΦ".
@@ -41,7 +41,7 @@ Lemma wp_Malloc_vec s E n :
   (0 < n)%Z →
   {{{ True }}}
     Malloc #n @ s ; E
-  {{{ l, RET #l; l ↦C∗ vreplicate (Z.to_nat n) None }}}.
+  {{{ l, RET #l; l I↦C∗ vreplicate (Z.to_nat n) None }}}.
 Proof.
   iIntros (Hzs Φ) "_ HΦ". iApply wp_Malloc; [ lia | done | .. ]. iModIntro.
   iIntros (l) "Hl". iApply "HΦ". rewrite vec_to_list_replicate. iFrame.
@@ -50,7 +50,7 @@ Qed.
 (** Accessing array elements *)
 Lemma wp_load_offset s E l dq off vs (v:val) :
   vs !! off = Some (Some v) →
-  {{{ ▷ l ↦C∗{dq} vs }}} * #(l +ₗ off) @ s; E {{{ RET v; l ↦C∗{dq} vs }}}%CE.
+  {{{ ▷ l I↦C∗{dq} vs }}} * #(l +ₗ off) @ s; E {{{ RET v; l I↦C∗{dq} vs }}}%CE.
 Proof.
   iIntros (Hlookup Φ) ">Hl HΦ".
   iDestruct (update_array l _ _ _ _ Hlookup with "Hl") as "[Hl1 Hl2]".
@@ -61,7 +61,7 @@ Qed.
 
 Lemma wp_store_offset s E l off vs (v:val) :
   off < length vs →
-  {{{ ▷ l ↦C∗ vs }}} #(l +ₗ off) <- v @ s; E {{{ RET #0; l ↦C∗ <[off:=Some v]> vs }}}%CE.
+  {{{ ▷ l I↦C∗ vs }}} #(l +ₗ off) <- v @ s; E {{{ RET #0; l I↦C∗ <[off:=Some v]> vs }}}%CE.
 Proof.
   iIntros (Hlength Φ) ">Hl HΦ".
   destruct (lookup_lt_is_Some_2 _ _ Hlength) as [vv Hlookup].
@@ -71,7 +71,7 @@ Proof.
 Qed.
 
 Lemma wp_store_offset_vec s E l sz (off : fin sz) (vs : vec (option val) sz) (v:val) :
-  {{{ ▷ l ↦C∗ vs }}} #(l +ₗ off) <- v @ s; E {{{ RET #0; l ↦C∗ vinsert off (Some v) vs }}}%CE.
+  {{{ ▷ l I↦C∗ vs }}} #(l +ₗ off) <- v @ s; E {{{ RET #0; l I↦C∗ vinsert off (Some v) vs }}}%CE.
 Proof.
   setoid_rewrite vec_to_list_insert. apply wp_store_offset.
   rewrite vec_to_list_length. apply fin_to_nat_lt.
@@ -79,7 +79,7 @@ Qed.
 
 (** Freeing a region *)
 Lemma wp_free_array s E l vs :
-  {{{ ▷ l ↦C∗ vs }}} free (#l, #(Z.of_nat (length vs))) @ s; E {{{ RET LitV LitUnit; True }}}%CE.
+  {{{ ▷ l I↦C∗ vs }}} free (#l, #(Z.of_nat (length vs))) @ s; E {{{ RET LitV LitUnit; True }}}%CE.
 Proof.
   iIntros (Φ) ">Hl HΦ".
   iApply (wp_step with "HΦ"). iApply wp_lift_atomic_head_step; first done.
@@ -115,7 +115,7 @@ Qed.
 
 Lemma wp_free_array' s E l z vs :
   z = Z.of_nat (length vs) →
-  {{{ ▷ l ↦C∗ vs }}} free (#l, #z) @ s; E {{{ RET LitV LitUnit; True }}}%CE.
+  {{{ ▷ l I↦C∗ vs }}} free (#l, #z) @ s; E {{{ RET LitV LitUnit; True }}}%CE.
 Proof. iIntros (-> Φ) "H HΦ". by iApply (wp_free_array with "H"). Qed.
 
 End lifting.

--- a/theories/examples/compression/buffers_code.v
+++ b/theories/examples/compression/buffers_code.v
@@ -18,19 +18,19 @@ Section C_code.
 (** See [buffers_specs] for more information about the in-memory layout of buffers. *)
 
 Definition buf_alloc_code (cap : expr) : expr :=
-  CAMLlocal: "bk" in 
-  CAMLlocal: "bf" in 
-  CAMLlocal: "bf2" in 
+  CAMLlocal: "bk" in
+  CAMLlocal: "bf" in
+  CAMLlocal: "bf2" in
   "bk" <- caml_alloc_custom ( ) ;;
   (Custom_contents ( *"bk" ) :=  malloc(Int_val (cap))) ;;
   "bf"    <- caml_alloc (#2, #0) ;;
   "bf2"   <- caml_alloc (#2, #0) ;;
   let: "bfref" := caml_alloc (#1, #0) in
-  Store_field ( &Field(  "bfref", #0), Val_int (#0)) ;;
-  Store_field ( &Field( *"bf", #0), "bfref") ;;
-  Store_field ( &Field( *"bf", #1), *"bf2") ;;
-  Store_field ( &Field( *"bf2", #0), cap) ;;
-  Store_field ( &Field( *"bf2", #1), *"bk") ;;
+  Store_field (  "bfref", #0, Val_int (#0)) ;;
+  Store_field ( *"bf", #0, "bfref") ;;
+  Store_field ( *"bf", #1, *"bf2") ;;
+  Store_field ( *"bf2", #0, cap) ;;
+  Store_field ( *"bf2", #1, *"bk") ;;
   CAMLreturn: * "bf" unregistering ["bk", "bf", "bf2"].
 Definition buf_alloc_fun := Fun [BNamed "cap"] (buf_alloc_code "cap") .
 Definition buf_alloc_name := "buf_alloc".
@@ -46,7 +46,7 @@ Definition buf_upd_code (iv jv f_arg bf_arg : expr) : expr :=
  (while: * "i" ≤ "j" do
     ( "bts" +ₗ ( *"i") <- Int_val (call: &"callback" with ( *"f", Val_int ( *"i"))) ;;
      (if: Int_val(Field(Field( *"bf", #0), #0)) < *"i" + #1
-      then Store_field (&Field(Field( *"bf", #0), #0), Val_int ( *"i" + #1))
+      then Store_field (Field( *"bf", #0), #0, Val_int ( *"i" + #1))
       else Skip) ;;
       "i" <- *"i" + #1 )) ;;
   free ("i", #1);;
@@ -61,7 +61,7 @@ Definition buf_free_code (bf : expr) : expr :=
   (if: "bts" ≠ #LitNull
       then free("bts", "cap") else Skip );;
   (Custom_contents(Field(Field( bf, #1), #1)) := #LitNull) ;;
-  Store_field (&Field(Field( bf, #0), #0), Val_int (#-1) ) ;;
+  Store_field (Field( bf, #0), #0, Val_int (#-1) ) ;;
   Val_int (#0).
 Definition buf_free_fun := Fun [BNamed "bf"] (buf_free_code "bf").
 Definition buf_free_name := "buf_free".
@@ -84,7 +84,7 @@ Definition wrap_compress_code (bf1 bf2 : expr) : expr :=
   let: "cap2p" := malloc(#1) in
  ("cap2p" <- Int_val(Field(Field(bf2, #1), #0))) ;;
   let: "res" := call: &buffy_compress_name with ("bts1", "used1", "bts2", "cap2p") in
-  Store_field(&Field(Field(bf2, #0), #0), Val_int( *"cap2p")) ;;
+  Store_field(Field(bf2, #0), #0, Val_int( *"cap2p")) ;;
   free ("cap2p", #1) ;;
   if: "res" = #0 then Val_int(#1) else Val_int(#0).
 Definition wrap_compress_fun := Fun [BNamed "bf1"; BNamed "bf2"] (wrap_compress_code "bf1" "bf2").

--- a/theories/examples/compression/buffers_specs.v
+++ b/theories/examples/compression/buffers_specs.v
@@ -60,7 +60,7 @@ Section Specs.
   Definition isBufferForeignBlock (γ : lloc) (ℓbuf : loc) (Pb : list (option Z) → iProp Σ) cap : iProp Σ :=
       ∃ vcontent, 
         "Hγfgnpto" ∷ γ ↦foreign (#ℓbuf)%CV
-      ∗ "Hℓbuf" ∷ ℓbuf ↦C∗ (map (option_map (λ (z:Z), #z)) vcontent)
+      ∗ "Hℓbuf" ∷ ℓbuf I↦C∗ (map (option_map (λ (z:Z), #z)) vcontent)
       ∗ "HContent" ∷ Pb vcontent
       ∗ "->" ∷ ⌜cap = length vcontent⌝.
 

--- a/theories/examples/compression/buffers_specs_simpler.v
+++ b/theories/examples/compression/buffers_specs_simpler.v
@@ -222,7 +222,7 @@ Section Specs.
   ∗ ⌜vcontent = fmap (option_map (λ (z:Z), #z)) zcontent⌝
   ∗ ⌜length vcontent = cap⌝
   ∗ ⌜a = #ℓ⌝
-  ∗ ℓ ↦C∗ vcontent.
+  ∗ ℓ I↦C∗ vcontent.
 
   Definition Pb (cap : nat) (arr : list Z) : list (option Z) → iProp Σ := (λ k, ∃ (zrest : list (option Z)), ⌜k = fmap Some arr ++ zrest⌝ ∗ ⌜cap = length k⌝)%I.
   Definition Pbu (arr : list Z) : nat → list (option Z) → iProp Σ := (λ used k, ∃ (zrest : list (option Z)), ⌜k = fmap Some arr ++ zrest⌝ ∗ ⌜used  = length arr⌝)%I.

--- a/theories/examples/compression/compression_proofs.v
+++ b/theories/examples/compression/compression_proofs.v
@@ -55,8 +55,8 @@ Qed.
 Lemma buffy_compress_rec_spec ℓin ℓout vin bin vspace :
    isBuffer vin bin →
    length vspace ≥ buffer_max_len (length bin) →
-(⊢  ℓin  ↦C∗ vin
- -∗ ℓout ↦C∗ vspace -∗
+(⊢  ℓin  I↦C∗ vin
+ -∗ ℓout I↦C∗ vspace -∗
     WP (call: &buffy_compress_rec_name with (Val #ℓin, Val #(length bin), Val #ℓout))%CE at ⟨ p , Ψ ⟩
     {{ v', ∃ bout vout vrest voverwritten,
              ⌜isBuffer vout bout⌝
@@ -64,8 +64,8 @@ Lemma buffy_compress_rec_spec ℓin ℓout vin bin vspace :
            ∗ ⌜v' = #(length vout)⌝
            ∗ ⌜vspace = voverwritten ++ vrest⌝
            ∗ ⌜length voverwritten = length vout⌝
-           ∗ ℓout ↦C∗ (vout ++ vrest)
-           ∗ ℓin  ↦C∗ vin }})%I.
+           ∗ ℓout I↦C∗ (vout ++ vrest)
+           ∗ ℓin  I↦C∗ vin }})%I.
 Proof using Hp.
   iIntros (HBuffer Hlength) "Hℓin Hℓout".
   iLöb as "IH" forall (ℓin ℓout vin bin vspace HBuffer Hlength).

--- a/theories/examples/compression/compression_specs.v
+++ b/theories/examples/compression/compression_specs.v
@@ -23,7 +23,7 @@ Definition buffy_compress_code (inbuf inlen outbuf outlenp:expr) := (
   if: *outlenp < call: &buffy_max_len_name with (inlen) then #1 else
     (outlenp <- call: &buffy_compress_rec_name with (inbuf, inlen, outbuf)) ;; #0 )%CE.
 
-Definition buffy_env : gmap string function := 
+Definition buffy_env : gmap string function :=
   <[buffy_max_len_name      := Fun [BNamed "len"] (buffy_max_len_code "len")]> (
   <[buffy_compress_rec_name := Fun [BNamed "inbuf"; BNamed "inlen"; BNamed "outbuf"] (buffy_compress_rec_code "inbuf" "inlen" "outbuf")]> (
   <[buffy_compress_name     := Fun [BNamed "inbuf"; BNamed "inlen"; BNamed "outbuf"; BNamed "outlenp"]
@@ -50,16 +50,16 @@ Definition buffy_compress_spec_ok : protocol val Σ := (λ s vv Φ,
   ∗ "->" ∷ ⌜vv = [ #ℓin; #(length bin); #ℓout; #ℓlen ]⌝
   ∗ "%Hlength" ∷ ⌜length vspace ≥ buffer_max_len (length bin)⌝
   ∗ "%HBuffer" ∷ ⌜isBuffer vin bin⌝
-  ∗ "Hℓin" ∷ ℓin  ↦C∗ vin
-  ∗ "Hℓout" ∷ ℓout ↦C∗ vspace
+  ∗ "Hℓin" ∷ ℓin  I↦C∗ vin
+  ∗ "Hℓout" ∷ ℓout I↦C∗ vspace
   ∗ "Hℓlen" ∷ ℓlen ↦C  #(length vspace)
   ∗ "HCont" ∷ ▷ (∀ bout vout vrest voverwritten,
          ⌜isBuffer vout bout⌝
       -∗ ⌜bout = compress_buffer bin⌝
       -∗ ⌜vspace = voverwritten ++ vrest⌝
       -∗ ⌜length voverwritten = length vout⌝
-      -∗ ℓout ↦C∗ (vout ++ vrest)
-      -∗ ℓin  ↦C∗ vin 
+      -∗ ℓout I↦C∗ (vout ++ vrest)
+      -∗ ℓin  I↦C∗ vin
       -∗ ℓlen ↦C  #(length vout)
       -∗ Φ #0))%I.
 

--- a/theories/examples/gmtime.v
+++ b/theories/examples/gmtime.v
@@ -1,0 +1,180 @@
+From iris.proofmode Require Import coq_tactics reduction spec_patterns.
+From iris.proofmode Require Export tactics.
+From iris.prelude Require Import options.
+From melocoton Require Import named_props.
+From melocoton.ml_lang.logrel Require logrel typing fundamental.
+From melocoton.interop Require Import basics basics_resources.
+From melocoton.lang_to_mlang Require Import lang weakestpre.
+From melocoton.interop Require Import lang weakestpre update_laws wp_utils wp_ext_call_laws wp_simulation.
+From melocoton.c_interop Require Import rules.
+From melocoton.ml_lang Require Import notation lang_instantiation.
+From melocoton.c_lang Require Import mlang_instantiation lang_instantiation.
+From melocoton.ml_lang Require proofmode.
+From melocoton.c_lang Require notation proofmode.
+From melocoton.mlanguage Require Import progenv.
+From melocoton.mlanguage Require weakestpre.
+From melocoton.linking Require Import lang weakestpre.
+From melocoton.combined Require Import adequacy rules.
+
+Section C_spec.
+
+  Import melocoton.c_interop.notation melocoton.c_lang.proofmode.
+
+  Context `{SI:indexT}.
+  Context  {Σ : gFunctors}.
+  Context `{!heapG_C Σ}.
+  Context `{!invG Σ}.
+
+  Definition gmtime_spec_C : protocol C_intf.val Σ:=
+    !! (w : Z)
+    {{ True }}
+      "gmtime" with ([ #C w ])
+    {{
+      (a : loc) (tm_sec : Z) (tm_min : Z), RET(#C a);
+      (* a ↦C∗ [tm_sec; tm_min] *)
+      ( a +ₗ 0 ) ↦C (#C tm_sec) ∗
+      ( a +ₗ 1 ) ↦C (#C tm_min)
+    }}.
+
+End C_spec.
+
+Section FFI_spec.
+
+  Import melocoton.c_interop.notation melocoton.c_lang.proofmode.
+
+  Context `{SI:indexT}.
+  Context `{!ffiG Σ}.
+
+  Definition caml_gmtime_code (t : expr) : expr :=
+    CAMLlocal: "res" in
+    let: "timer" := Int_val (t) in
+    let: "tm"    := (call: &"gmtime" with ("timer")) in
+    "res" <- caml_alloc (#2, #0);;
+
+    let: "tm_sec" := Val_int ( *( "tm" +ₗ #0 ) )  in
+    let: "tm_min" := Val_int ( *( "tm" +ₗ #1 ) )  in
+
+    Store_field( *"res", #0, "tm_sec" );;
+    Store_field( *"res", #1, "tm_min" );;
+
+    CAMLreturn: *"res" unregistering [ "res" ].
+
+  Definition caml_gmtime_prog : lang_prog C_lang :=
+    {[ "caml_gmtime" := Fun [BNamed "t"] (caml_gmtime_code "t") ]}.
+
+  Definition caml_gmtime_spec : protocol ML_lang.val Σ :=
+    !! (t : Z)
+      {{ True }}
+        "caml_gmtime" with [(#ML t)]
+      {{
+        (tm_sec : Z) (tm_min : Z), RET((#ML tm_sec, #ML tm_min)%MLV);
+        True
+      }}.
+
+  Lemma gmtime_correct :
+    (prims_proto caml_gmtime_spec) ⊔ gmtime_spec_C
+    ||- caml_gmtime_prog :: wrap_proto caml_gmtime_spec.
+  Proof.
+    iIntros (fn ws Φ) "H". iNamed "H". iNamedProto "Hproto".
+    iSplit; first done. iIntros (Φ'') "HΦ".
+    iAssert (⌜length lvs = 1⌝)%I as %Hlen.
+    { by iDestruct (big_sepL2_length with "Hsim") as %?. }
+    destruct lvs as [|lv []]; try by (exfalso; eauto with lia); []. clear Hlen.
+    destruct ws as [|w []]; try by (exfalso; apply Forall2_length in Hrepr; eauto with lia); [].
+    apply Forall2_cons_1 in Hrepr as [Hrepr _].
+    cbn. iDestruct "Hsim" as "[-> _]".
+    wp_call_direct.
+
+    (* Declare result variable *)
+    wp_apply (wp_CAMLlocal with "HGC"); eauto. iIntros (ℓ) "(HGC&Hℓ)". wp_pures.
+
+    (* Call stdlib gmtime *)
+    wp_apply (wp_val2int with "HGC"); eauto. iIntros "HGC". wp_pures.
+    wp_extern. iModIntro. iRight.
+    iSplit; first done.
+    iExists t; do 2 (iSplit; first done).
+    iIntros (a tm_sec tm_min). iNext.
+    iIntros "(Ha0&Ha1)". simpl. wp_pures.
+
+    (* Allocate result variable *)
+    wp_apply (wp_alloc (TagDefault) with "HGC"); try done; auto.
+    iIntros (θ' γ' w0') "(HGC&Hγ&%H2)".
+    wp_apply (store_to_root with "[$HGC $Hℓ]"); try done.
+    iIntros "(HGC&Hℓ)". wp_pures.
+
+    (* Convert tm_sec to ml int *)
+    wp_apply (wp_load with "[Ha0]"); try auto.
+    iIntros "Ha0".
+    wp_apply (wp_int2val with "HGC"); try auto.
+    iIntros (w0) "(HGC&%Htms)". wp_pures.
+
+    (* Convert tm_min to ml int *)
+    wp_apply (wp_load with "[Ha1]"); try auto.
+    iIntros "Ha1".
+    wp_apply (wp_int2val with "HGC"); try auto.
+    iIntros (w1) "(HGC&%Htmm)". wp_pures.
+
+    (* Load tm_sec *)
+    wp_apply (load_from_root with "[$HGC $Hℓ]").
+    iIntros (w2) "(Hℓ&HGC&%Hγ2)".
+    wp_apply (wp_modify with "[$HGC $Hγ]"); try eauto.
+    1: simpl; done.
+    iIntros "(HGC&Hγ)". wp_pures.
+
+    (* Load tm_min *)
+    wp_apply (load_from_root with "[$HGC $Hℓ]").
+    iIntros (w3) "(Hℓ&HGC&%Hγ3)".
+    wp_apply (wp_modify with "[$HGC $Hγ]"); try eauto.
+    1: simpl; done.
+    iIntros "(HGC&Hγ)". wp_pures.
+
+    (* Return *)
+    wp_apply (load_from_root with "[$HGC $Hℓ]").
+    iIntros (w4) "(Hℓ&HGC&Hγ4)". wp_pures.
+
+    wp_apply (wp_unregisterroot with "[$HGC $Hℓ]"); try eauto.
+    iIntros (w5) "(HGC&hℓ&%Hγ5)". wp_pures.
+    wp_free. wp_pures.
+
+    iMod (freeze_to_immut γ' _ θ' with "[$]") as "(HGC&#Hγ')".
+
+    iModIntro.
+    iApply "HΦ".
+    iApply ("Return" with "[$HGC] [Cont] []").
+    - by iApply "Cont".
+    - cbn. iExists γ'. iExists _, _. iSplit; try eauto.
+    - eauto.
+Qed.
+
+End FFI_spec.
+
+Section ML_spec.
+  Import melocoton.ml_lang.proofmode.
+  Import logrel typing fundamental.
+
+  Context `{SI:indexT}.
+  Context `{!ffiG Σ}.
+  Context `{!logrelG Σ}.
+
+  Definition program_type_ctx : program_env :=
+    {[ "caml_gmtime" := FunType [ TNat ] (TProd TNat TNat) ]}.
+
+  Lemma gmtime_well_typed Δ : ⊢ ⟦ program_type_ctx ⟧ₚ* ⟨∅, caml_gmtime_spec⟩ Δ.
+  Proof.
+    iIntros (s vv Φ) "!> (%ats&%rt&%Heq&Hargs&Htok&HCont)".
+    wp_extern. iModIntro. unfold program_type_ctx in Heq.
+    apply lookup_singleton_Some in Heq as (<-&Heq). simplify_eq.
+    iPoseProof (big_sepL2_length with "Hargs") as "%Heq".
+    destruct vv as [|v [|??]]; cbn in Heq; try lia.
+    cbn. iDestruct "Hargs" as "((%n&->)&_)".
+    iSplit; first done. iExists n.
+    do 2 (iSplit; first done).
+    iIntros "!>" (tm_sec tm_min) "_". wp_pures. iModIntro.
+    iApply ("HCont" with "[-Htok] Htok").
+    iExists (#ML tm_sec), (#ML tm_min).
+    iSplit; first done.
+    iSplit; iExists _; done.
+  Qed.
+
+End ML_spec.
+

--- a/theories/examples/gmtime.v
+++ b/theories/examples/gmtime.v
@@ -176,5 +176,27 @@ Section ML_spec.
     iSplit; iExists _; done.
   Qed.
 
+
 End ML_spec.
+
+Section ML_Example.
+
+  Import melocoton.ml_lang.proofmode.
+
+  Context `{SI:indexT}.
+  Context `{!ffiG Σ}.
+
+  Definition gmtime_client : mlanguage.expr (lang_to_mlang ML_lang) :=
+    (Fst (Extern "caml_gmtime" [ (Val #0)%MLE ])).
+
+  Lemma ML_prog_correct_axiomatic :
+    ⊢ WP gmtime_client at ⟨∅, caml_gmtime_spec⟩ {{ v, ⌜∃x : Z, v = #x⌝}}.
+  Proof.
+    unfold gmtime_client. wp_pures. wp_extern.
+    iModIntro. cbn. iSplit; first done. iExists _.
+    do 2 (iSplitR; first done). iIntros "!>" (tm_sec tm_min) "_".
+    wp_pures. iModIntro. iPureIntro. by eexists.
+  Qed.
+
+End ML_Example.
 

--- a/theories/examples/gmtime.v
+++ b/theories/examples/gmtime.v
@@ -31,9 +31,7 @@ Section C_spec.
       "gmtime" with ([ #C w ])
     {{
       (a : loc) (tm_sec : Z) (tm_min : Z), RET(#C a);
-      (* a ↦C∗ [tm_sec; tm_min] *)
-      ( a +ₗ 0 ) ↦C (#C tm_sec) ∗
-      ( a +ₗ 1 ) ↦C (#C tm_min)
+      a ↦C∗ [ #C tm_sec; #C tm_min ]
     }}.
 
 End C_spec.
@@ -94,7 +92,8 @@ Section FFI_spec.
     iSplit; first done.
     iExists t; do 2 (iSplit; first done).
     iIntros (a tm_sec tm_min). iNext.
-    iIntros "(Ha0&Ha1)". simpl. wp_pures.
+    cbn.
+    iIntros "(Ha0&Ha1&_)". wp_pures.
 
     (* Allocate result variable *)
     wp_apply (wp_alloc (TagDefault) with "HGC"); try done; auto.

--- a/theories/examples/swap_pair.v
+++ b/theories/examples/swap_pair.v
@@ -118,7 +118,7 @@ Proof.
   repr_lval_inj. wp_pures.
 
   (* free *)
-  iAssert ((Loc rr) ↦C∗ [Some wlv1'; Some wlv2'])%I with "[H1 H2]" as "Hrr".
+  iAssert ((Loc rr) ↦C∗ [wlv1'; wlv2'])%I with "[H1 H2]" as "Hrr".
   1: cbn; iFrame.
   wp_apply (wp_free_array' with "Hrr"); first done. iIntros "_".
   wp_pures.

--- a/theories/examples/swap_variant.v
+++ b/theories/examples/swap_variant.v
@@ -139,9 +139,8 @@ Proof.
   repr_lval_inj. wp_pures.
 
   (* free *)
-  iAssert (rr ↦C∗ [Some wlv'])%I with "[H]" as "Hrr".
-  1: cbn; rewrite loc_add_0; iFrame.
-  wp_apply (wp_free_array' with "Hrr"); first done. iIntros "_".
+  iAssert (rr ↦C wlv')%I with "[H]" as "Hrr"; first done.
+  wp_apply (wp_free with "Hrr"). iIntros "_".
   wp_pures.
 
   (* Finish, convert the new points-to to an immutable pointsto *)

--- a/theories/language_commons.v
+++ b/theories/language_commons.v
@@ -178,6 +178,20 @@ Proof.
   { iApply bi.or_intro_r. by iApply Hre2. }
 Qed.
 
+Lemma proto_join_l val Σ (ψ ψ1 ψ2 : protocol val Σ) :
+  ψ ⊑ ψ1 → ψ ⊑ ψ1 ⊔ ψ2.
+Proof.
+  iIntros (H ? ? ?) "H".
+  iApply bi.or_intro_l. by iApply H.
+Qed.
+
+Lemma proto_join_r val Σ (ψ ψ1 ψ2 : protocol val Σ) :
+  ψ ⊑ ψ2 → ψ ⊑ ψ1 ⊔ ψ2.
+Proof.
+  iIntros (H ? ? ?) "H".
+  iApply bi.or_intro_r. by iApply H.
+Qed.
+
 Global Instance proto_join_ne val Σ : NonExpansive2 (@proto_join val Σ).
 Proof.
   rewrite /proto_join /= => n pp1 pp2 Hpp qq1 qq2 Hqq.
@@ -185,6 +199,9 @@ Proof.
 Qed.
 
 End Protocols.
+
+Global Hint Resolve proto_join_r : core.
+Global Hint Resolve proto_join_l : core.
 
 (* Reexport notations *)
 Notation "Ψ 'except' fns" := (proto_except Ψ fns) (at level 10).

--- a/theories/ml_lang/notation.v
+++ b/theories/ml_lang/notation.v
@@ -34,7 +34,7 @@ Notation Skip := (App (Val $ LamV BAnon (Val $ LitV LitUnit)) (Val $ LitV LitUni
    direction we would want. So we keep this global for now, and use #ML whenever
    we need to be explicit. *)
 Notation "# l" := (LitV l%Z%MLV%stdpp) (at level 8, format "# l").
-Notation "#ML l" := (LitV l%Z%MLV%stdpp) (at level 8, format "#ML l").
+Notation "#ML l" := (LitV l%Z%MLV%stdpp) (at level 8, format "#ML  l").
 
 (** Syntax inspired by Coq/Ocaml. Constructions with higher precedence come
     first. *)


### PR DESCRIPTION
Added one new example specifying a simpler version of the `gmtime` function from the `Unix` module.
 
While adding this example, I found that  new proofs were needed inside `theories/language_commons.v` to simplify the usage of joined protocols. 

I also changed the `Store_field` notation to be closer to the FFI.