### PR TITLE
Add support for boxed integers

### DIFF
--- a/theories/c_interop/notation.v
+++ b/theories/c_interop/notation.v
@@ -25,6 +25,10 @@ Notation "'Val_int' '(' x ')'" := (call: &"int2val" with (x%CE))%CE
   (at level 70, x at level 69,
   format "'Val_int' '(' x ')'") : c_expr_scope.
 
+Notation "'BoxedInt_val' '(' x ')'" := (call: &"read_foreign" with (x%CE))%CE
+  (at level 70, x at level 69,
+  format "'BoxedInt_val' '(' x ')'") : c_expr_scope.
+
 Notation "'Custom_contents' '(' x ')'" := (call: &"read_foreign" with (x%CE))%CE
   (at level 70, x at level 69,
   format "'Custom_contents' '(' x ')'") : c_expr_scope.

--- a/theories/c_interop/rules.v
+++ b/theories/c_interop/rules.v
@@ -260,7 +260,7 @@ Lemma wp_alloc_foreign p Ψ θ :
   {{{ GC θ }}}
     (call: &"alloc_foreign" with ( ))%CE at ⟨p, Ψ⟩
   {{{ θ' γ w, RET w;
-        GC θ' ∗ γ ↦foreignO None ∗
+        GC θ' ∗ γ ↦foreignO[Mut] None ∗
         ⌜repr_lval θ' (Lloc γ) w⌝ }}}.
 Proof.
   intros Hp Hproto **. iIntros "HGC Cont".
@@ -276,9 +276,9 @@ Lemma wp_write_foreign p Ψ θ w γ ao a' :
   p !! "write_foreign" = None →
   write_foreign_proto ⊑ Ψ →
   repr_lval θ (Lloc γ) w →
-  {{{ GC θ ∗ γ ↦foreignO ao }}}
+  {{{ GC θ ∗ γ ↦foreignO[Mut] ao }}}
     (call: &"write_foreign" with (Val w, Val a'))%CE at ⟨p, Ψ⟩
-  {{{ RET (# 0); GC θ ∗ γ ↦foreign a' }}}.
+  {{{ RET (# 0); GC θ ∗ γ ↦foreign[Mut] a' }}}.
 Proof.
   intros Hp Hproto **. iIntros "(HGC & ?) Cont".
   wp_pures. wp_extern; first done.
@@ -289,19 +289,19 @@ Proof.
   iApply wp_value; eauto. iApply "Cont"; eauto. by iFrame.
 Qed.
 
-Lemma wp_read_foreign p Ψ θ w γ a dq :
+Lemma wp_read_foreign p Ψ θ w γ a m dq :
   p !! "read_foreign" = None →
   read_foreign_proto ⊑ Ψ →
   repr_lval θ (Lloc γ) w →
-  {{{ GC θ ∗ γ ↦foreign{dq} a }}}
+  {{{ GC θ ∗ γ ↦foreign[m]{dq} a }}}
     (call: &"read_foreign" with (Val w))%CE at ⟨p, Ψ⟩
-  {{{ RET a; GC θ ∗ γ ↦foreign{dq} a }}}.
+  {{{ RET a; GC θ ∗ γ ↦foreign[m]{dq} a }}}.
 Proof.
   intros Hp Hproto **. iIntros "(HGC & ?) Cont".
   wp_pures. wp_extern; first done.
   iModIntro. cbn. iApply Hproto.
   rewrite /read_foreign_proto /named. iSplit; first done.
-  do 5 iExists _. iFrame.
+  do 6 iExists _. iFrame.
   do 2 (iSplit; first by eauto with lia). iIntros "!> [? ?]".
   iApply wp_value; eauto. iApply "Cont"; eauto. by iFrame.
 Qed.

--- a/theories/examples/box.v
+++ b/theories/examples/box.v
@@ -70,7 +70,7 @@ Section Proofs.
   Solve Obligations with solve_proper.
 
   Program Definition box_interp : (protocol ML_lang.val Σ) -n> (listO D -n> D) -d> listO D -n> D := λne Ψ, λ interp, λne Δ, PersPred (
-    λ v, ∃ (γ:nat) (ℓ:loc), ⌜v = #(LitForeign γ)⌝ ∗ γ ↦foreign{DfracDiscarded} (#C ℓ) ∗
+    λ v, ∃ (γ:nat) (ℓ:loc), ⌜v = #(LitForeign γ)⌝ ∗ γ ↦foreign[Mut]{DfracDiscarded} (#C ℓ) ∗
            na_inv logrel_nais (nroot .@ "value"   .@ γ) (box_invariant_1 (ℓ +ₗ 1) (interp Δ)) ∗
            na_inv logrel_nais (nroot .@ "callback".@ γ) (box_invariant_2 ℓ (interp_arrow ⟨ ∅ , Ψ ⟩ interp interp_unit Δ)))%I.
   Next Obligation. solve_proper. Qed.

--- a/theories/examples/box.v
+++ b/theories/examples/box.v
@@ -70,7 +70,7 @@ Section Proofs.
   Solve Obligations with solve_proper.
 
   Program Definition box_interp : (protocol ML_lang.val Σ) -n> (listO D -n> D) -d> listO D -n> D := λne Ψ, λ interp, λne Δ, PersPred (
-    λ v, ∃ (γ:nat) (ℓ:loc), ⌜v = #(LitForeign γ)⌝ ∗ γ ↦foreign[Mut]{DfracDiscarded} (#C ℓ) ∗
+    λ v, ∃ (γ:nat) (ℓ:loc), ⌜v = #(LitForeign γ)⌝ ∗ γ ↦foreign[Immut]{DfracDiscarded} (#C ℓ) ∗
            na_inv logrel_nais (nroot .@ "value"   .@ γ) (box_invariant_1 (ℓ +ₗ 1) (interp Δ)) ∗
            na_inv logrel_nais (nroot .@ "callback".@ γ) (box_invariant_2 ℓ (interp_arrow ⟨ ∅ , Ψ ⟩ interp interp_unit Δ)))%I.
   Next Obligation. solve_proper. Qed.
@@ -139,16 +139,17 @@ Section Proofs.
     wp_pures.
     wp_apply (wp_write_foreign with "[$HGC $Hγfgn]"); [done..|].
     iIntros "(HGC&Hγfgn)". wp_pures.
-    iDestruct "Hγfgn" as "(Hγfgn'&_)".
+    iDestruct "Hγfgn" as "(Hγfgn'&Hγfresh)".
     iMod (na_inv_alloc logrel_nais _ _ (box_invariant_1 (ℓ +ₗ 1) (interp Δ)) with "[Hℓ1]") as "#Hinv1".
     { iNext. iExists _, _. iFrame "Hℓ1 Hsimv Hv". }
     iMod (na_inv_alloc logrel_nais _ _ (box_invariant_2 ℓ (interp_arrow ⟨ ∅ , Ψ ⟩ interp interp_unit Δ)) with "[Hℓ0]") as "#Hinv2".
     { iNext. iRight. iFrame. }
-    iMod (ghost_map.ghost_map_elem_persist with "Hγfgn'") as "#Hγfgn'".
+    iMod (freeze_foreign_to_immut γ θ1 _ with "[$]") as "(HGC&#Hγfgn)".
     iModIntro. iApply "Cont2". iApply ("Return" $! θ1 (#(LitForeign γ)) with "HGC [-] [] []").
     2,3: done.
     iApply "Cont". iFrame "Hna". iExists γ, ℓ.
-    iSplit; first done. iSplitL; first done.
+    iSplit; first done. 
+    iSplitL; first done.
     iFrame "Hinv1 Hinv2".
   Qed.
 

--- a/theories/examples/box.v
+++ b/theories/examples/box.v
@@ -70,7 +70,7 @@ Section Proofs.
   Solve Obligations with solve_proper.
 
   Program Definition box_interp : (protocol ML_lang.val Σ) -n> (listO D -n> D) -d> listO D -n> D := λne Ψ, λ interp, λne Δ, PersPred (
-    λ v, ∃ (γ:nat) (ℓ:loc), ⌜v = #(LitForeign γ)⌝ ∗ γ ↦foreign[Immut]{DfracDiscarded} (#C ℓ) ∗
+    λ v, ∃ (γ:nat) (ℓ:loc), ⌜v = #(LitForeign γ)⌝ ∗ γ ↦foreign[Immut] (#C ℓ) ∗
            na_inv logrel_nais (nroot .@ "value"   .@ γ) (box_invariant_1 (ℓ +ₗ 1) (interp Δ)) ∗
            na_inv logrel_nais (nroot .@ "callback".@ γ) (box_invariant_2 ℓ (interp_arrow ⟨ ∅ , Ψ ⟩ interp interp_unit Δ)))%I.
   Next Obligation. solve_proper. Qed.

--- a/theories/examples/box.v
+++ b/theories/examples/box.v
@@ -116,43 +116,41 @@ Section Proofs.
   Lemma box_create_correct :
     prims_proto Ψ ||- box_prog :: wrap_proto box_create_spec_ML.
   Proof.
-  Admitted.
-  (*   iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto". *)
-  (*   iSplit; first done. *)
-  (*   destruct lvs as [|lvl [|??]]; try done. *)
-  (*   all: cbn; iDestruct "Hsim" as "(Hsimv&Hsim)"; try done. *)
-  (*   destruct ws as [|wv [|??]]; decompose_Forall. *)
-  (*   iIntros (Φ'') "Cont2". *)
-  (*   wp_pure _. *)
-  (*   wp_apply (wp_Malloc); [done..|]. *)
-  (*   change (Z.to_nat 2) with 2. cbn. *)
-  (*   iIntros (ℓ) "(Hℓ0&Hℓ1&_)". *)
-  (*   replace ((ℓ +ₗ 0%nat)) with ℓ by by rewrite loc_add_0. *)
-  (*   wp_pures. *)
-  (*   wp_apply (wp_store with "Hℓ0"). iIntros "Hℓ0". *)
-  (*   wp_pures. *)
-  (*   wp_apply (wp_store with "Hℓ1"). iIntros "Hℓ1". *)
-  (*   wp_pures. *)
-  (*   wp_apply (wp_registerroot with "[$HGC $Hℓ1]"); [done..|]. *)
-  (*   iIntros "(HGC&Hℓ1)". wp_pures. *)
-  (*   wp_apply (wp_alloc_foreign with "HGC"); [done..|]. *)
-  (*   iIntros (θ1 γ w) "(HGC&Hγfgn&%Hrepr)". *)
-  (*   wp_pures. *)
-  (*   wp_apply (wp_write_foreign with "[$HGC $Hγfgn]"); [done..|]. *)
-  (*   iIntros "(HGC&Hγfgn)". wp_pures. *)
-  (*   iDestruct "Hγfgn" as "(Hγfgn'&_)". *)
-  (*   iMod (na_inv_alloc logrel_nais _ _ (box_invariant_1 (ℓ +ₗ 1) (interp Δ)) with "[Hℓ1]") as "#Hinv1". *)
-  (*   { iNext. iExists _, _. iFrame "Hℓ1 Hsimv Hv". } *)
-  (*   iMod (na_inv_alloc logrel_nais _ _ (box_invariant_2 ℓ (interp_arrow ⟨ ∅ , Ψ ⟩ interp interp_unit Δ)) with "[Hℓ0]") as "#Hinv2". *)
-  (*   { iNext. iRight. iFrame. } *)
-  (*   iMod (ghost_map.ghost_map_elem_persist with "Hγfgn'") as "#Hγfgn'". *)
-  (*   iModIntro. iApply "Cont2". iApply ("Return" $! θ1 (#(LitForeign γ)) with "HGC [-] [] []"). *)
-  (*   2,3: done. *)
-  (*   iApply "Cont". iFrame "Hna". iExists γ, ℓ. *)
-  (*   iSplit; first done. iSplitL. *)
-  (*   { iSplitL. 2: done. iApply "Hγfgn'". } *)
-  (*   iFrame "Hinv1 Hinv2". *)
-  (* Qed. *)
+    iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto".
+    iSplit; first done.
+    destruct lvs as [|lvl [|??]]; try done.
+    all: iEval (cbn) in "Hsim"; iDestruct "Hsim" as "(Hsimv&Hsim)"; try done.
+    destruct ws as [|wv [|??]]; decompose_Forall.
+    iIntros (Φ'') "Cont2".
+    wp_pure _.
+    wp_apply (wp_Malloc); [done..|].
+    change (Z.to_nat 2) with 2. cbn.
+    iIntros (ℓ) "(Hℓ0&Hℓ1&_)".
+    replace ((ℓ +ₗ 0%nat)) with ℓ by by rewrite loc_add_0.
+    wp_pures.
+    wp_apply (wp_store with "Hℓ0"). iIntros "Hℓ0".
+    wp_pures.
+    wp_apply (wp_store with "Hℓ1"). iIntros "Hℓ1".
+    wp_pures.
+    wp_apply (wp_registerroot with "[$HGC $Hℓ1]"); [done..|].
+    iIntros "(HGC&Hℓ1)". wp_pures.
+    wp_apply (wp_alloc_foreign with "HGC"); [done..|].
+    iIntros (θ1 γ w) "(HGC&Hγfgn&%Hrepr)".
+    wp_pures.
+    wp_apply (wp_write_foreign with "[$HGC $Hγfgn]"); [done..|].
+    iIntros "(HGC&Hγfgn)". wp_pures.
+    iDestruct "Hγfgn" as "(Hγfgn'&_)".
+    iMod (na_inv_alloc logrel_nais _ _ (box_invariant_1 (ℓ +ₗ 1) (interp Δ)) with "[Hℓ1]") as "#Hinv1".
+    { iNext. iExists _, _. iFrame "Hℓ1 Hsimv Hv". }
+    iMod (na_inv_alloc logrel_nais _ _ (box_invariant_2 ℓ (interp_arrow ⟨ ∅ , Ψ ⟩ interp interp_unit Δ)) with "[Hℓ0]") as "#Hinv2".
+    { iNext. iRight. iFrame. }
+    iMod (ghost_map.ghost_map_elem_persist with "Hγfgn'") as "#Hγfgn'".
+    iModIntro. iApply "Cont2". iApply ("Return" $! θ1 (#(LitForeign γ)) with "HGC [-] [] []").
+    2,3: done.
+    iApply "Cont". iFrame "Hna". iExists γ, ℓ.
+    iSplit; first done. iSplitL; first done.
+    iFrame "Hinv1 Hinv2".
+  Qed.
 
   Lemma box_update_correct :
     prims_proto Ψ ||- box_prog :: wrap_proto box_update_spec_ML.
@@ -160,8 +158,8 @@ Section Proofs.
     iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto".
     iSplit; first done.
     destruct lvs as [|lvn [|lvb [|??]]]; try done.
-    all: cbn; iDestruct "Hsim" as "(Hsimvn&Hsim)"; try done.
-    all: cbn; iDestruct "Hsim" as "(Hsimvb&Hsim)"; try done.
+    all: iEval (cbn) in "Hsim"; iDestruct "Hsim" as "(Hsimvn&Hsim)"; try done.
+    all: iEval (cbn) in "Hsim"; iDestruct "Hsim" as "(Hsimvb&Hsim)"; try done.
     destruct ws as [|wn [|wb [|??]]]; decompose_Forall.
     iIntros (Φ'') "Cont2".
     wp_pure _.
@@ -210,15 +208,14 @@ Section Proofs.
       iApply ("Return" with "HGC (Cont Hna) [//] [//]").
   Qed.
 
-
   Lemma box_listen_correct :
     prims_proto Ψ ||- box_prog :: wrap_proto box_listen_spec_ML.
   Proof.
     iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto".
     iSplit; first done.
     destruct lvs as [|lv [|lvb [|??]]]; try done.
-    all: cbn; iDestruct "Hsim" as "(Hsimvl&Hsim)"; try done.
-    all: cbn; iDestruct "Hsim" as "(Hsimvb&Hsim)"; try done.
+    all: iEval (cbn) in "Hsim"; iDestruct "Hsim" as "(Hsimvl&Hsim)"; try done.
+    all: iEval (cbn) in "Hsim"; iDestruct "Hsim" as "(Hsimvb&Hsim)"; try done.
     destruct ws as [|wl [|wb [|??]]]; decompose_Forall.
     iIntros (Φ'') "Cont2".
     wp_pure _.
@@ -254,6 +251,7 @@ Section Proofs.
       iIntros (w0) "(HGC&%Hw0)". iApply "Cont2".
       iApply ("Return" with "HGC (Cont Hna) [//] [//]").
   Qed.
+
   End InPsi.
 
   Definition box_prog_spec_ML (Ψ : protocol ML_lang.val Σ) : protocol ML_lang.val Σ :=
@@ -281,6 +279,7 @@ Section Proofs.
   Proof.
     exact (fixpoint_unfold (box_prog_spec_ML) s vv Φ).
   Qed.
+
   Lemma buf_library_spec_ML_sim:
    (box_prog_spec_ML (box_spec_ML) ⊑ box_spec_ML)%I.
   Proof.

--- a/theories/examples/box.v
+++ b/theories/examples/box.v
@@ -116,42 +116,43 @@ Section Proofs.
   Lemma box_create_correct :
     prims_proto Ψ ||- box_prog :: wrap_proto box_create_spec_ML.
   Proof.
-    iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto".
-    iSplit; first done.
-    destruct lvs as [|lvl [|??]]; try done.
-    all: cbn; iDestruct "Hsim" as "(Hsimv&Hsim)"; try done.
-    destruct ws as [|wv [|??]]; decompose_Forall.
-    iIntros (Φ'') "Cont2".
-    wp_pure _.
-    wp_apply (wp_Malloc); [done..|].
-    change (Z.to_nat 2) with 2. cbn.
-    iIntros (ℓ) "(Hℓ0&Hℓ1&_)".
-    replace ((ℓ +ₗ 0%nat)) with ℓ by by rewrite loc_add_0.
-    wp_pures.
-    wp_apply (wp_store with "Hℓ0"). iIntros "Hℓ0".
-    wp_pures.
-    wp_apply (wp_store with "Hℓ1"). iIntros "Hℓ1".
-    wp_pures.
-    wp_apply (wp_registerroot with "[$HGC $Hℓ1]"); [done..|].
-    iIntros "(HGC&Hℓ1)". wp_pures.
-    wp_apply (wp_alloc_foreign with "HGC"); [done..|].
-    iIntros (θ1 γ w) "(HGC&Hγfgn&%Hrepr)".
-    wp_pures.
-    wp_apply (wp_write_foreign with "[$HGC $Hγfgn]"); [done..|].
-    iIntros "(HGC&Hγfgn)". wp_pures.
-    iDestruct "Hγfgn" as "(Hγfgn'&_)".
-    iMod (na_inv_alloc logrel_nais _ _ (box_invariant_1 (ℓ +ₗ 1) (interp Δ)) with "[Hℓ1]") as "#Hinv1".
-    { iNext. iExists _, _. iFrame "Hℓ1 Hsimv Hv". }
-    iMod (na_inv_alloc logrel_nais _ _ (box_invariant_2 ℓ (interp_arrow ⟨ ∅ , Ψ ⟩ interp interp_unit Δ)) with "[Hℓ0]") as "#Hinv2".
-    { iNext. iRight. iFrame. }
-    iMod (ghost_map.ghost_map_elem_persist with "Hγfgn'") as "#Hγfgn'".
-    iModIntro. iApply "Cont2". iApply ("Return" $! θ1 (#(LitForeign γ)) with "HGC [-] [] []").
-    2,3: done.
-    iApply "Cont". iFrame "Hna". iExists γ, ℓ.
-    iSplit; first done. iSplitL.
-    { iSplitL. 2: done. iApply "Hγfgn'". }
-    iFrame "Hinv1 Hinv2".
-  Qed.
+  Admitted.
+  (*   iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto". *)
+  (*   iSplit; first done. *)
+  (*   destruct lvs as [|lvl [|??]]; try done. *)
+  (*   all: cbn; iDestruct "Hsim" as "(Hsimv&Hsim)"; try done. *)
+  (*   destruct ws as [|wv [|??]]; decompose_Forall. *)
+  (*   iIntros (Φ'') "Cont2". *)
+  (*   wp_pure _. *)
+  (*   wp_apply (wp_Malloc); [done..|]. *)
+  (*   change (Z.to_nat 2) with 2. cbn. *)
+  (*   iIntros (ℓ) "(Hℓ0&Hℓ1&_)". *)
+  (*   replace ((ℓ +ₗ 0%nat)) with ℓ by by rewrite loc_add_0. *)
+  (*   wp_pures. *)
+  (*   wp_apply (wp_store with "Hℓ0"). iIntros "Hℓ0". *)
+  (*   wp_pures. *)
+  (*   wp_apply (wp_store with "Hℓ1"). iIntros "Hℓ1". *)
+  (*   wp_pures. *)
+  (*   wp_apply (wp_registerroot with "[$HGC $Hℓ1]"); [done..|]. *)
+  (*   iIntros "(HGC&Hℓ1)". wp_pures. *)
+  (*   wp_apply (wp_alloc_foreign with "HGC"); [done..|]. *)
+  (*   iIntros (θ1 γ w) "(HGC&Hγfgn&%Hrepr)". *)
+  (*   wp_pures. *)
+  (*   wp_apply (wp_write_foreign with "[$HGC $Hγfgn]"); [done..|]. *)
+  (*   iIntros "(HGC&Hγfgn)". wp_pures. *)
+  (*   iDestruct "Hγfgn" as "(Hγfgn'&_)". *)
+  (*   iMod (na_inv_alloc logrel_nais _ _ (box_invariant_1 (ℓ +ₗ 1) (interp Δ)) with "[Hℓ1]") as "#Hinv1". *)
+  (*   { iNext. iExists _, _. iFrame "Hℓ1 Hsimv Hv". } *)
+  (*   iMod (na_inv_alloc logrel_nais _ _ (box_invariant_2 ℓ (interp_arrow ⟨ ∅ , Ψ ⟩ interp interp_unit Δ)) with "[Hℓ0]") as "#Hinv2". *)
+  (*   { iNext. iRight. iFrame. } *)
+  (*   iMod (ghost_map.ghost_map_elem_persist with "Hγfgn'") as "#Hγfgn'". *)
+  (*   iModIntro. iApply "Cont2". iApply ("Return" $! θ1 (#(LitForeign γ)) with "HGC [-] [] []"). *)
+  (*   2,3: done. *)
+  (*   iApply "Cont". iFrame "Hna". iExists γ, ℓ. *)
+  (*   iSplit; first done. iSplitL. *)
+  (*   { iSplitL. 2: done. iApply "Hγfgn'". } *)
+  (*   iFrame "Hinv1 Hinv2". *)
+  (* Qed. *)
 
   Lemma box_update_correct :
     prims_proto Ψ ||- box_prog :: wrap_proto box_update_spec_ML.

--- a/theories/examples/compression/buffers_proof_alloc.v
+++ b/theories/examples/compression/buffers_proof_alloc.v
@@ -27,7 +27,7 @@ Section Proofs.
        GC θ' ∗ isBufferRecord lv ℓ (buf_alloc_res_buffer n) n ∗
        ⌜repr_lval θ' lv w'⌝ }}}%CE.
   Proof.
-    cbn. iIntros (Hb1 Hlval Φ) "HGC HΦ". wp_call_direct.
+    iIntros (Hb1 Hlval Φ) "HGC HΦ". wp_call_direct.
     wp_apply (wp_CAMLlocal with "HGC"); [done..|].
     iIntros (ℓbk) "(HGC&Hℓbk)"; wp_pures.
     wp_apply (wp_CAMLlocal with "HGC"); [done..|].
@@ -101,19 +101,15 @@ Section Proofs.
     change (Z.to_nat 0) with 0.
     change (Z.to_nat 1) with 1.
     change (Z.to_nat 2) with 2.
-    cbn.
     iMod (freeze_to_immut with "[$HGC $Hγbf]") as "(HGC&Hγbf)".
     iMod (freeze_to_immut with "[$HGC $Hγbf2]") as "(HGC&Hγbf2)".
     iMod (freeze_to_mut with "[$HGC $Hγbfref]") as "(HGC&Hγbfref)".
-
-    iPoseProof "Hγbk" as "(Hγbk&%Hγbk)".
 
     iAssert (isBufferRecord (Lloc γbf) ℓbts (buf_alloc_res_buffer n) n) with "[Hγbk Hγbf Hγbf2 Hγbfref Hbts]" as "Hbuffer".
     { iExists γbf, γbfref, γbf2, γbk, 0. unfold named. iFrame.
       iSplit; first done.
       iExists (replicate n None). unfold named, lstore_own_foreign.
       rewrite map_replicate; cbn.
-      iFrame. iSplit; first done.
       rewrite (_: Z.to_nat n = n); last lia. iFrame.
       iPureIntro; split_and!.
       1: done.

--- a/theories/examples/compression/buffers_specs.v
+++ b/theories/examples/compression/buffers_specs.v
@@ -59,7 +59,7 @@ Section Specs.
 
   Definition isBufferForeignBlock (γ : lloc) (ℓbuf : loc) (Pb : list (option Z) → iProp Σ) cap : iProp Σ :=
       ∃ vcontent, 
-        "Hγfgnpto" ∷ γ ↦foreign (#ℓbuf)%CV
+        "Hγfgnpto" ∷ γ ↦foreign[Mut] (#ℓbuf)%CV
       ∗ "Hℓbuf" ∷ ℓbuf I↦C∗ (map (option_map (λ (z:Z), #z)) vcontent)
       ∗ "HContent" ∷ Pb vcontent
       ∗ "->" ∷ ⌜cap = length vcontent⌝.
@@ -157,7 +157,7 @@ Section Specs.
     ∗ "Hbuf" ∷ isBufferRecordML v ℓ Pb cap
     ∗ "HCont" ∷ ▷   ( ∀ (ℓML:loc) γfgn, ⌜v = (# ℓML, (# cap, # (LitForeign γfgn)))%MLV⌝ -∗
                                          ℓML ↦M #(-1) -∗
-                                         γfgn ↦foreign (#C LitNull) -∗ Φ #()).
+                                         γfgn ↦foreign[Mut] (#C LitNull) -∗ Φ #()).
 
   Definition buf_get_spec_ML s vv Φ : iProp Σ :=
     ∃ v ℓ Pb cap (idx:nat) (res:Z),

--- a/theories/examples/gmtime.v
+++ b/theories/examples/gmtime.v
@@ -80,8 +80,8 @@ Section FFI_spec.
     destruct lvs as [|lv []]; try by (exfalso; eauto with lia); []. clear Hlen.
     destruct ws as [|w []]; try by (exfalso; apply Forall2_length in Hrepr; eauto with lia); [].
     apply Forall2_cons_1 in Hrepr as [Hrepr _].
-    cbn -[lstore_own_elem].
-    iDestruct "Hsim" as "[Hγ Hemp]".
+    cbn.
+    iDestruct "Hsim" as "[Hγ _]".
     iDestruct "Hγ" as (γ) "[-> Hγ]".
     wp_call_direct.
 

--- a/theories/examples/is_eq.v
+++ b/theories/examples/is_eq.v
@@ -58,6 +58,7 @@ Section C_specs.
     match τ with
     | TUnit | TNat | TBool => True
     | TProd τ1 τ2 | TSum τ1 τ2 => valid_is_eq_type τ1 ∧ valid_is_eq_type τ2
+    | TBoxedNat
     | TArray _ | TArrow _ _ | TRec _ | TVar _ | TForall _ | TExist _ => False
     end.
 

--- a/theories/examples/listener.v
+++ b/theories/examples/listener.v
@@ -72,7 +72,7 @@ Section Proofs.
   Solve Obligations with solve_proper.
 
   Program Definition listener_interp : (protocol ML_lang.val Σ) -n> (listO D -n> D) -d> listO D -n> D := λne Ψ, λ interp, λne Δ, PersPred (
-    λ v, ∃ γ (a:addr), ⌜v = #(LitForeign γ)⌝ ∗ γ ↦foreign{DfracDiscarded} (#C a) ∗
+    λ v, ∃ γ (a:addr), ⌜v = #(LitForeign γ)⌝ ∗ γ ↦foreign[Mut]{DfracDiscarded} (#C a) ∗
            na_inv logrel_nais (nroot .@ "listener" .@ γ)
              (listener_invariant a (interp_arrow ⟨ ∅ , Ψ ⟩ interp interp_unit Δ)))%I.
   Next Obligation. solve_proper. Qed.

--- a/theories/examples/listener.v
+++ b/theories/examples/listener.v
@@ -126,36 +126,37 @@ Section Proofs.
   Lemma listener_create_correct :
     prims_proto Ψ ||- listener_prog :: wrap_proto listener_create_spec_ML.
   Proof.
-    iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto".
-    iSplit; first done.
-    destruct lvs as [|lvl [|??]]; try done.
-    all: cbn; iDestruct "Hsim" as "(->&Hsim)"; try done.
-    destruct ws as [|wv [|??]]; decompose_Forall.
-    iIntros (Φ'') "Cont2".
-    wp_pure _.
-    wp_apply (wp_Malloc); [done..|].
-    change (Z.to_nat 1) with 1. cbn.
-    iIntros (a) "(Ha&_)".
-    replace ((a +ₗ 0%nat)) with a by by rewrite loc_add_0.
-    wp_pures.
-    wp_apply (wp_store with "Ha"). iIntros "Ha".
-    wp_pures.
-    wp_apply (wp_alloc_foreign with "HGC"); [done..|].
-    iIntros (θ1 γ w) "(HGC&Hγfgn&%Hrepr)".
-    wp_pures.
-    wp_apply (wp_write_foreign with "[$HGC $Hγfgn]"); [done..|].
-    iIntros "(HGC&Hγfgn)". wp_pures.
-    iDestruct "Hγfgn" as "(Hγfgn'&_)".
-    iMod (na_inv_alloc logrel_nais _ _ (listener_invariant a _) with "[Ha]") as "#Hinv".
-    { iNext. iRight. iFrame "Ha". }
-    iMod (ghost_map.ghost_map_elem_persist with "Hγfgn'") as "#Hγfgn'".
-    iModIntro. iApply "Cont2". iApply ("Return" $! θ1 (#(LitForeign γ)) with "HGC [-] [] []").
-    2,3: done.
-    iApply "Cont". iFrame "Hna". iExists γ, a.
-    iSplit; first done. iSplitL.
-    { iSplitL. 2: done. iApply "Hγfgn'". }
-    iFrame "Hinv".
-  Qed.
+  Admitted.
+  (*   iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto". *)
+  (*   iSplit; first done. *)
+  (*   destruct lvs as [|lvl [|??]]; try done. *)
+  (*   all: cbn; iDestruct "Hsim" as "(->&Hsim)"; try done. *)
+  (*   destruct ws as [|wv [|??]]; decompose_Forall. *)
+  (*   iIntros (Φ'') "Cont2". *)
+  (*   wp_pure _. *)
+  (*   wp_apply (wp_Malloc); [done..|]. *)
+  (*   change (Z.to_nat 1) with 1. cbn. *)
+  (*   iIntros (a) "(Ha&_)". *)
+  (*   replace ((a +ₗ 0%nat)) with a by by rewrite loc_add_0. *)
+  (*   wp_pures. *)
+  (*   wp_apply (wp_store with "Ha"). iIntros "Ha". *)
+  (*   wp_pures. *)
+  (*   wp_apply (wp_alloc_foreign with "HGC"); [done..|]. *)
+  (*   iIntros (θ1 γ w) "(HGC&Hγfgn&%Hrepr)". *)
+  (*   wp_pures. *)
+  (*   wp_apply (wp_write_foreign with "[$HGC $Hγfgn]"); [done..|]. *)
+  (*   iIntros "(HGC&Hγfgn)". wp_pures. *)
+  (*   iDestruct "Hγfgn" as "(Hγfgn'&_)". *)
+  (*   iMod (na_inv_alloc logrel_nais _ _ (listener_invariant a _) with "[Ha]") as "#Hinv". *)
+  (*   { iNext. iRight. iFrame "Ha". } *)
+  (*   iMod (ghost_map.ghost_map_elem_persist with "Hγfgn'") as "#Hγfgn'". *)
+  (*   iModIntro. iApply "Cont2". iApply ("Return" $! θ1 (#(LitForeign γ)) with "HGC [-] [] []"). *)
+  (*   2,3: done. *)
+  (*   iApply "Cont". iFrame "Hna". iExists γ, a. *)
+  (*   iSplit; first done. iSplitL. *)
+  (*   { iSplitL. 2: done. iApply "Hγfgn'". } *)
+  (*   iFrame "Hinv". *)
+  (* Qed. *)
 
   Lemma listener_notify_correct :
     prims_proto Ψ ||- listener_prog :: wrap_proto listener_notify_spec_ML.

--- a/theories/examples/listener.v
+++ b/theories/examples/listener.v
@@ -72,7 +72,7 @@ Section Proofs.
   Solve Obligations with solve_proper.
 
   Program Definition listener_interp : (protocol ML_lang.val Σ) -n> (listO D -n> D) -d> listO D -n> D := λne Ψ, λ interp, λne Δ, PersPred (
-    λ v, ∃ γ (a:addr), ⌜v = #(LitForeign γ)⌝ ∗ γ ↦foreign[Immut]{DfracDiscarded} (#C a) ∗
+    λ v, ∃ γ (a:addr), ⌜v = #(LitForeign γ)⌝ ∗ γ ↦foreign[Immut] (#C a) ∗
            na_inv logrel_nais (nroot .@ "listener" .@ γ)
              (listener_invariant a (interp_arrow ⟨ ∅ , Ψ ⟩ interp interp_unit Δ)))%I.
   Next Obligation. solve_proper. Qed.

--- a/theories/examples/listener.v
+++ b/theories/examples/listener.v
@@ -72,7 +72,7 @@ Section Proofs.
   Solve Obligations with solve_proper.
 
   Program Definition listener_interp : (protocol ML_lang.val Σ) -n> (listO D -n> D) -d> listO D -n> D := λne Ψ, λ interp, λne Δ, PersPred (
-    λ v, ∃ γ (a:addr), ⌜v = #(LitForeign γ)⌝ ∗ γ ↦foreign[Mut]{DfracDiscarded} (#C a) ∗
+    λ v, ∃ γ (a:addr), ⌜v = #(LitForeign γ)⌝ ∗ γ ↦foreign[Immut]{DfracDiscarded} (#C a) ∗
            na_inv logrel_nais (nroot .@ "listener" .@ γ)
              (listener_invariant a (interp_arrow ⟨ ∅ , Ψ ⟩ interp interp_unit Δ)))%I.
   Next Obligation. solve_proper. Qed.
@@ -145,10 +145,10 @@ Section Proofs.
     wp_pures.
     wp_apply (wp_write_foreign with "[$HGC $Hγfgn]"); [done..|].
     iIntros "(HGC&Hγfgn)". wp_pures.
-    iDestruct "Hγfgn" as "(Hγfgn'&_)".
+    iDestruct "Hγfgn" as "(Hγfgn'&Hγfresh)".
     iMod (na_inv_alloc logrel_nais _ _ (listener_invariant a _) with "[Ha]") as "#Hinv".
     { iNext. iRight. iFrame "Ha". }
-    iMod (ghost_map.ghost_map_elem_persist with "Hγfgn'") as "#Hγfgn'".
+    iMod (freeze_foreign_to_immut γ θ1 _ with "[$]") as "(HGC&#Hγfgn')".
     iModIntro. iApply "Cont2". iApply ("Return" $! θ1 (#(LitForeign γ)) with "HGC [-] [] []").
     2,3: done.
     iApply "Cont". iFrame "Hna". iExists γ, a.

--- a/theories/examples/listener.v
+++ b/theories/examples/listener.v
@@ -126,37 +126,36 @@ Section Proofs.
   Lemma listener_create_correct :
     prims_proto Ψ ||- listener_prog :: wrap_proto listener_create_spec_ML.
   Proof.
-  Admitted.
-  (*   iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto". *)
-  (*   iSplit; first done. *)
-  (*   destruct lvs as [|lvl [|??]]; try done. *)
-  (*   all: cbn; iDestruct "Hsim" as "(->&Hsim)"; try done. *)
-  (*   destruct ws as [|wv [|??]]; decompose_Forall. *)
-  (*   iIntros (Φ'') "Cont2". *)
-  (*   wp_pure _. *)
-  (*   wp_apply (wp_Malloc); [done..|]. *)
-  (*   change (Z.to_nat 1) with 1. cbn. *)
-  (*   iIntros (a) "(Ha&_)". *)
-  (*   replace ((a +ₗ 0%nat)) with a by by rewrite loc_add_0. *)
-  (*   wp_pures. *)
-  (*   wp_apply (wp_store with "Ha"). iIntros "Ha". *)
-  (*   wp_pures. *)
-  (*   wp_apply (wp_alloc_foreign with "HGC"); [done..|]. *)
-  (*   iIntros (θ1 γ w) "(HGC&Hγfgn&%Hrepr)". *)
-  (*   wp_pures. *)
-  (*   wp_apply (wp_write_foreign with "[$HGC $Hγfgn]"); [done..|]. *)
-  (*   iIntros "(HGC&Hγfgn)". wp_pures. *)
-  (*   iDestruct "Hγfgn" as "(Hγfgn'&_)". *)
-  (*   iMod (na_inv_alloc logrel_nais _ _ (listener_invariant a _) with "[Ha]") as "#Hinv". *)
-  (*   { iNext. iRight. iFrame "Ha". } *)
-  (*   iMod (ghost_map.ghost_map_elem_persist with "Hγfgn'") as "#Hγfgn'". *)
-  (*   iModIntro. iApply "Cont2". iApply ("Return" $! θ1 (#(LitForeign γ)) with "HGC [-] [] []"). *)
-  (*   2,3: done. *)
-  (*   iApply "Cont". iFrame "Hna". iExists γ, a. *)
-  (*   iSplit; first done. iSplitL. *)
-  (*   { iSplitL. 2: done. iApply "Hγfgn'". } *)
-  (*   iFrame "Hinv". *)
-  (* Qed. *)
+    iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto".
+    iSplit; first done.
+    destruct lvs as [|lvl [|??]]; try done.
+    all: iEval (cbn) in "Hsim"; iDestruct "Hsim" as "(->&Hsim)"; try done.
+    destruct ws as [|wv [|??]]; decompose_Forall.
+    iIntros (Φ'') "Cont2".
+    wp_pure _.
+    wp_apply (wp_Malloc); [done..|].
+    change (Z.to_nat 1) with 1. cbn.
+    iIntros (a) "(Ha&_)".
+    replace ((a +ₗ 0%nat)) with a by by rewrite loc_add_0.
+    wp_pures.
+    wp_apply (wp_store with "Ha"). iIntros "Ha".
+    wp_pures.
+    wp_apply (wp_alloc_foreign with "HGC"); [done..|].
+    iIntros (θ1 γ w) "(HGC&Hγfgn&%Hrepr)".
+    wp_pures.
+    wp_apply (wp_write_foreign with "[$HGC $Hγfgn]"); [done..|].
+    iIntros "(HGC&Hγfgn)". wp_pures.
+    iDestruct "Hγfgn" as "(Hγfgn'&_)".
+    iMod (na_inv_alloc logrel_nais _ _ (listener_invariant a _) with "[Ha]") as "#Hinv".
+    { iNext. iRight. iFrame "Ha". }
+    iMod (ghost_map.ghost_map_elem_persist with "Hγfgn'") as "#Hγfgn'".
+    iModIntro. iApply "Cont2". iApply ("Return" $! θ1 (#(LitForeign γ)) with "HGC [-] [] []").
+    2,3: done.
+    iApply "Cont". iFrame "Hna". iExists γ, a.
+    iSplit; first done. iSplitL.
+    { iApply "Hγfgn'". }
+    iFrame "Hinv".
+  Qed.
 
   Lemma listener_notify_correct :
     prims_proto Ψ ||- listener_prog :: wrap_proto listener_notify_spec_ML.
@@ -196,7 +195,7 @@ Section Proofs.
       iApply "Cont2". iApply ("Return" with "HGC [Cont Hna] [] []").
       1: by iApply "Cont". 1,2: by iPureIntro.
     - wp_apply (wp_load with "[$Hnull]"). iIntros "Hnull".
-      wp_pures. 
+      wp_pures.
       iMod ("Hclose" with "[$Hna Hnull]") as "Hna".
       { iNext. iRight. iFrame. }
       wp_apply (wp_int2val with "HGC"); [done..|].
@@ -261,7 +260,7 @@ Section Proofs.
     iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto".
     iSplit; first done.
     destruct lvs as [|lv [|lvb [|??]]]; try done.
-    all: cbn; iDestruct "Hsim" as "(Hsimvb&Hsim)"; try done.
+    all: iEval (cbn) in "Hsim"; iDestruct "Hsim" as "(Hsimvb&Hsim)"; try done.
     destruct ws as [|wl [|wb [|??]]]; decompose_Forall.
     iIntros (Φ'') "Cont2".
     wp_pure _.
@@ -299,6 +298,7 @@ Section Proofs.
       iApply "Cont2". iApply ("Return" with "HGC [Cont Hna]").
       1: by iApply "Cont". 1,2: by iPureIntro.
   Qed.
+
   End InPsi.
 
   Definition listener_prog_spec_ML (Ψ : protocol ML_lang.val Σ) : protocol ML_lang.val Σ :=
@@ -351,7 +351,7 @@ Section Proofs.
                                                          (λ: "v1" "v2", extern: "listener_listen" with ("v1", "v2")),
                                                          (λ: "v1", extern: "listener_unlisten" with ("v1"))).
 
-  
+
   Definition ML_type_inner (t:type) : type :=
     (TProd (TProd (TProd
        (* unit -> 'a listener *)
@@ -423,7 +423,7 @@ Section Proofs.
     let: <> := Snd (Fst "l") (λ: "v", Snd (Fst (Fst "l")) (#1) "ml") "ml" in
     #42.
 
-  Lemma listener_client_1_typed : 
+  Lemma listener_client_1_typed :
     typed ∅ ∅ listener_client_1 (TArrow ML_type TNat).
   Proof.
     econstructor; cbn in *.
@@ -447,7 +447,7 @@ Section Proofs.
 End Proofs.
 
 
-Lemma listener_client_1_adequacy : 
+Lemma listener_client_1_adequacy :
 umrel.trace (mlanguage.prim_step (combined_prog listener_client listener_prog))
   (LkCall "main" [], adequacy.σ_init)
   (λ '(e, σ), ∃ x, mlanguage.to_val e = Some (code_int x) ∧ True).

--- a/theories/examples/new_boxedint.v
+++ b/theories/examples/new_boxedint.v
@@ -16,26 +16,6 @@ From melocoton.mlanguage Require weakestpre.
 From melocoton.linking Require Import lang weakestpre.
 From melocoton.combined Require Import adequacy rules.
 
-Section C_spec.
-
-  Import melocoton.c_interop.notation melocoton.c_lang.proofmode.
-
-  Context `{SI:indexT}.
-  Context  {Σ : gFunctors}.
-  Context `{!heapG_C Σ}.
-  Context `{!invG Σ}.
-
-  Definition new_boxedint_spec_C : protocol C_intf.val Σ:=
-    !!
-    {{ True }}
-      "new_boxedint" with []
-    {{
-      (a : loc), RET(#C a);
-      a ↦C ( #C 0 )
-    }}.
-
-End C_spec.
-
 Section FFI_spec.
 
   Import melocoton.c_interop.notation melocoton.c_lang.proofmode.
@@ -61,7 +41,7 @@ Section FFI_spec.
       }}.
 
   Lemma new_boxedint_correct :
-    (prims_proto caml_new_boxedint_spec) ⊔ new_boxedint_spec_C
+    prims_proto caml_new_boxedint_spec
     ||- caml_new_boxedint_prog :: wrap_proto caml_new_boxedint_spec.
   Proof.
     iIntros (fn ws Φ) "H". iNamed "H". iNamedProto "Hproto".
@@ -70,7 +50,6 @@ Section FFI_spec.
     { by iDestruct (big_sepL2_length with "Hsim") as %?. }
     destruct lvs as [|lv []]; try by (exfalso; eauto with lia); []. clear Hlen.
     destruct ws as [|w []]; try by (exfalso; apply Forall2_length in Hrepr; eauto with lia); [].
-    (* apply Forall2_cons_1 in Hrepr as [Hrepr _]. *)
     cbn.
     wp_call_direct.
 

--- a/theories/examples/zigzag_list.v
+++ b/theories/examples/zigzag_list.v
@@ -213,28 +213,30 @@ Section Proofs.
   Lemma zigzag_head_correct :
     prims_proto Ψ ||- zigzag_prog :: wrap_proto zigzag_head_spec_ML.
   Proof.
-    iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto".
-    iSplit; first done.
-    destruct lvs as [|lvhd [|??]]; try done.
-    all: cbn; iDestruct "Hsim" as "(Hsimlst&Hsim)"; try done.
-    destruct ws as [|wlst [|??]]; decompose_Forall.
-    iDestruct "Htl" as  "(%γ&%ww&->&Hγfgn&%a&%lv1&%lv2&%Vlst&->&Ha0&#Hsim0&Ha1&#Hsim1&Hrec)".
-    iDestruct "Hsimlst" as "->".
-    iIntros (Φ'') "Cont2".
-    wp_apply (wp_call _ _ _ _ [_]);
-      [by unfold zigzag_prog; solve_lookup_fixed|done|].
-    wp_finish.
-    wp_apply (wp_read_foreign with "[$HGC $Hγfgn]"); [done..|]. iIntros "(HGC&Hγfgn)".
-    wp_pure _.
-    rewrite loc_add_0.
-    wp_apply (load_from_root with "[$HGC $Ha0]").
-    iIntros (whd) "(Ha0&HGC&%Hrepr)".
-    iApply "Cont2".
-    iApply ("Return" with "HGC [-]"); last done.
-    - iApply "Cont". iExists γ, _. iSplit; first done. iFrame "Hγfgn".
-      iExists a, lv1, lv2, Vlst. iFrame "Ha0 Ha1 Hsim0 Hsim1 Hrec". done.
-    - done.
-  Qed.
+  Admitted.
+  (*   iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto". *)
+  (*   iSplit; first done. *)
+  (*   destruct lvs as [|lvhd [|??]]; try done. *)
+  (*   all: cbn; iDestruct "Hsim" as "(Hsimlst&Hsim)"; try done. *)
+  (*   destruct ws as [|wlst [|??]]; decompose_Forall. *)
+  (*   iDestruct "Htl" as  "(%γ&%ww&->&Hγfgn&%a&%lv1&%lv2&%Vlst&->&Ha0&#Hsim0&Ha1&#Hsim1&Hrec)". *)
+  (*   iDestruct "Hsimlst" as "->". *)
+  (*   iIntros (Φ'') "Cont2". *)
+  (*   wp_apply (wp_call _ _ _ _ [_]); *)
+  (*     [by unfold zigzag_prog; solve_lookup_fixed|done|]. *)
+  (*   wp_finish. *)
+  (*   wp_apply (wp_read_foreign with "[$HGC $Hγfgn]"); [done..|]. iIntros "(HGC&Hγfgn)". *)
+  (*   wp_pure _. *)
+  (*   rewrite loc_add_0. *)
+  (*   wp_apply (load_from_root with "[$HGC $Ha0]"). *)
+  (*   iIntros (whd) "(Ha0&HGC&%Hrepr)". *)
+  (*   iApply "Cont2". *)
+  (*   iApply ("Return" with "HGC [-]"); last done. *)
+  (*   - iApply "Cont". iExists γ, _. iSplit; first done. iFrame "Hγfgn". *)
+  (*     iExists a, lv1, lv2, Vlst. iFrame "Ha0 Ha1 Hsim0 Hsim1 Hrec". done. *)
+  (*   - done. *)
+  (* Qed. *)
+  (**)
 
   Lemma zigzag_tail_correct :
     prims_proto Ψ ||- zigzag_prog :: wrap_proto zigzag_tail_spec_ML.

--- a/theories/examples/zigzag_list.v
+++ b/theories/examples/zigzag_list.v
@@ -213,30 +213,28 @@ Section Proofs.
   Lemma zigzag_head_correct :
     prims_proto Ψ ||- zigzag_prog :: wrap_proto zigzag_head_spec_ML.
   Proof.
-  Admitted.
-  (*   iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto". *)
-  (*   iSplit; first done. *)
-  (*   destruct lvs as [|lvhd [|??]]; try done. *)
-  (*   all: cbn; iDestruct "Hsim" as "(Hsimlst&Hsim)"; try done. *)
-  (*   destruct ws as [|wlst [|??]]; decompose_Forall. *)
-  (*   iDestruct "Htl" as  "(%γ&%ww&->&Hγfgn&%a&%lv1&%lv2&%Vlst&->&Ha0&#Hsim0&Ha1&#Hsim1&Hrec)". *)
-  (*   iDestruct "Hsimlst" as "->". *)
-  (*   iIntros (Φ'') "Cont2". *)
-  (*   wp_apply (wp_call _ _ _ _ [_]); *)
-  (*     [by unfold zigzag_prog; solve_lookup_fixed|done|]. *)
-  (*   wp_finish. *)
-  (*   wp_apply (wp_read_foreign with "[$HGC $Hγfgn]"); [done..|]. iIntros "(HGC&Hγfgn)". *)
-  (*   wp_pure _. *)
-  (*   rewrite loc_add_0. *)
-  (*   wp_apply (load_from_root with "[$HGC $Ha0]"). *)
-  (*   iIntros (whd) "(Ha0&HGC&%Hrepr)". *)
-  (*   iApply "Cont2". *)
-  (*   iApply ("Return" with "HGC [-]"); last done. *)
-  (*   - iApply "Cont". iExists γ, _. iSplit; first done. iFrame "Hγfgn". *)
-  (*     iExists a, lv1, lv2, Vlst. iFrame "Ha0 Ha1 Hsim0 Hsim1 Hrec". done. *)
-  (*   - done. *)
-  (* Qed. *)
-  (**)
+    iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto".
+    iSplit; first done.
+    destruct lvs as [|lvhd [|??]]; try done.
+    all: iEval (cbn) in "Hsim"; iDestruct "Hsim" as "(Hsimlst&Hsim)"; try done.
+    destruct ws as [|wlst [|??]]; decompose_Forall.
+    iDestruct "Htl" as  "(%γ&%ww&->&Hγfgn&%a&%lv1&%lv2&%Vlst&->&Ha0&#Hsim0&Ha1&#Hsim1&Hrec)".
+    iDestruct "Hsimlst" as "->".
+    iIntros (Φ'') "Cont2".
+    wp_apply (wp_call _ _ _ _ [_]);
+      [by unfold zigzag_prog; solve_lookup_fixed|done|].
+    wp_finish.
+    wp_apply (wp_read_foreign with "[$HGC $Hγfgn]"); [done..|]. iIntros "(HGC&Hγfgn)".
+    wp_pure _.
+    rewrite loc_add_0.
+    wp_apply (load_from_root with "[$HGC $Ha0]").
+    iIntros (whd) "(Ha0&HGC&%Hrepr)".
+    iApply "Cont2".
+    iApply ("Return" with "HGC [-]"); last done.
+    - iApply "Cont". iExists γ, _. iSplit; first done. iFrame "Hγfgn".
+      iExists a, lv1, lv2, Vlst. iFrame "Ha0 Ha1 Hsim0 Hsim1 Hrec". done.
+    - done.
+  Qed.
 
   Lemma zigzag_tail_correct :
     prims_proto Ψ ||- zigzag_prog :: wrap_proto zigzag_tail_spec_ML.
@@ -244,7 +242,7 @@ Section Proofs.
     iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto".
     iSplit; first done.
     destruct lvs as [|lvhd [|??]]; try done.
-    all: cbn; iDestruct "Hsim" as "(Hsimlst&Hsim)"; try done.
+    all: iEval (cbn) in "Hsim"; iDestruct "Hsim" as "(Hsimlst&Hsim)"; try done.
     destruct ws as [|wlst [|??]]; decompose_Forall.
     iDestruct "Htl" as  "(%γ&%ww&->&Hγfgn&%a&%lv1&%lv2&%Vlst&->&Ha0&#Hsim0&Ha1&#Hsim1&Hrec)".
     iDestruct "Hsimlst" as "->".
@@ -270,7 +268,7 @@ Section Proofs.
     iIntros (s ws Φ) "H". iNamed "H". iNamedProto "Hproto".
     iSplit; first done.
     destruct lvs as [|lvhd [|??]]; try done.
-    all: cbn; iDestruct "Hsim" as "(Hsimlst&Hsim)"; try done.
+    all: iEval (cbn) in "Hsim"; iDestruct "Hsim" as "(Hsimlst&Hsim)"; try done.
     destruct ws as [|wlst [|??]]; decompose_Forall.
     iDestruct "Htl" as  "(%γ&%ww&->&Hγfgn&%a&%lv1&%lv2&%Vlst&->&Ha0&#Hsim0&Ha1&#Hsim1&Hrec)".
     iDestruct "Hsimlst" as "->".
@@ -294,6 +292,7 @@ Section Proofs.
     iApply ("Return" with "HGC (Cont [$Hrec Hγfgn])"); [|done..].
     iExists _, _; iSplit; first done. iFrame "Hγfgn". done.
   Qed.
+
   End InPsi.
 
   Definition zigzag_spec_ML : protocol ML_lang.val Σ :=

--- a/theories/examples/zigzag_list.v
+++ b/theories/examples/zigzag_list.v
@@ -73,7 +73,7 @@ Section Proofs.
   Context `{!primitive_laws.heapG_ML Σ, !wrapperG Σ, !logrelG Σ}.
 
   Fixpoint is_zigzag (lst : list MLval) (v : MLval) : iProp Σ :=
-    ∃ γ w, ⌜v = #(LitForeign γ)⌝ ∗ γ ↦foreign (#C w)
+    ∃ γ w, ⌜v = #(LitForeign γ)⌝ ∗ γ ↦foreign[Mut] (#C w)
            ∗ match lst with
              | nil => ⌜w = LitNull⌝
              | (v1::vr) => ∃ (a:addr) lv1 lv2 Vlst, ⌜w = a⌝ ∗ a ↦roots lv1 ∗ lv1 ~~ v1

--- a/theories/interop/basics_constructions.v
+++ b/theories/interop/basics_constructions.v
@@ -165,8 +165,9 @@ Lemma deserialize_ML_value χMLold v :
     extended_to χMLold ζimm χC
   ∧ is_val χC ζimm v lv.
 Proof.
-  induction v as [[x|bo| |ℓ|]| |v1 IHv1 v2 IHv2|v IHv|v IHv] in χMLold|-*; intros Hinj.
+  induction v as [[x|bo| |n|ℓ|]| |v1 IHv1 v2 IHv2|v IHv|v IHv] in χMLold|-*; intros Hinj.
   1-3: eexists χMLold, ∅, _; split_and!; [by eapply extended_to_refl | econstructor ].
+  - admit.
   - destruct (ensure_in_χ_pub χMLold ℓ) as (χ' & γ & Hχ' & Hγ & _); first done.
     exists χ', ∅, (Lloc γ); (split_and!; last by econstructor).
     by eapply extended_to_mono.
@@ -211,7 +212,7 @@ Proof.
       eapply map_disjoint_Some_r. 1: eapply extended_to_trans_2; done.
       apply lookup_singleton.
     + eapply is_val_extended_to_weaken; done.
-Qed.
+Admitted.
 
 Lemma deserialize_ML_values χMLold vs :  
   lloc_map_inj χMLold

--- a/theories/interop/basics_constructions.v
+++ b/theories/interop/basics_constructions.v
@@ -167,7 +167,7 @@ Lemma deserialize_ML_value χMLold v :
 Proof.
   induction v as [[x|bo| |x|ℓ|]| |v1 IHv1 v2 IHv2|v IHv|v IHv] in χMLold|-*; intros Hinj.
   1-3: eexists χMLold, ∅, _; split_and!; [by eapply extended_to_refl | econstructor ].
-  - pose (Bforeign Immut (Some (C_intf.LitV (C_intf.LitInt x)))) as blk.
+  - pose (Bforeign (Immut, (Some (#C x)))) as blk.
     destruct (allocate_in_χ_priv χMLold blk) as (χ & γ & Hextend); first done.
     eexists χ, _, (Lloc γ). split; eauto. econstructor. by simplify_map_eq.
   - destruct (ensure_in_χ_pub χMLold ℓ) as (χ' & γ & Hχ' & Hγ & _); first done.

--- a/theories/interop/basics_constructions.v
+++ b/theories/interop/basics_constructions.v
@@ -108,7 +108,7 @@ Proof.
   - eapply elem_of_weaken; first apply HB. done.
 Qed.
 
-Lemma extended_to_trans (χ1 χ2 χ3 : lloc_map) (ζ1 ζ2 : lstore) : 
+Lemma extended_to_trans (χ1 χ2 χ3 : lloc_map) (ζ1 ζ2 : lstore) :
   extended_to χ1 ζ1 χ2 →
   extended_to χ2 ζ2 χ3 →
   extended_to χ1 (ζ1 ∪ ζ2) χ3 /\ ζ1 ##ₘ ζ2.
@@ -124,7 +124,7 @@ Proof.
     eapply extended_to_dom_subset; done.
 Qed.
 
-Lemma extended_to_trans_2 (χ1 χ2 χ3 : lloc_map) (ζ1 ζ2 : lstore) : 
+Lemma extended_to_trans_2 (χ1 χ2 χ3 : lloc_map) (ζ1 ζ2 : lstore) :
   extended_to χ1 ζ1 χ2 →
   extended_to χ2 ζ2 χ3 →
   extended_to χ1 (ζ2 ∪ ζ1) χ3 /\ ζ1 ##ₘ ζ2.
@@ -159,15 +159,17 @@ Proof.
   apply map_union_subseteq_l.
 Qed.
 
-Lemma deserialize_ML_value χMLold v :  
+Lemma deserialize_ML_value χMLold v :
   lloc_map_inj χMLold
 → ∃ χC ζimm lv,
     extended_to χMLold ζimm χC
   ∧ is_val χC ζimm v lv.
 Proof.
-  induction v as [[x|bo| |n|ℓ|]| |v1 IHv1 v2 IHv2|v IHv|v IHv] in χMLold|-*; intros Hinj.
+  induction v as [[x|bo| |x|ℓ|]| |v1 IHv1 v2 IHv2|v IHv|v IHv] in χMLold|-*; intros Hinj.
   1-3: eexists χMLold, ∅, _; split_and!; [by eapply extended_to_refl | econstructor ].
-  - admit.
+  - pose (Bforeign Immut (Some (C_intf.LitV (C_intf.LitInt x)))) as blk.
+    destruct (allocate_in_χ_priv χMLold blk) as (χ & γ & Hextend); first done.
+    eexists χ, _, (Lloc γ). split; eauto. econstructor. by simplify_map_eq.
   - destruct (ensure_in_χ_pub χMLold ℓ) as (χ' & γ & Hχ' & Hγ & _); first done.
     exists χ', ∅, (Lloc γ); (split_and!; last by econstructor).
     by eapply extended_to_mono.
@@ -212,9 +214,9 @@ Proof.
       eapply map_disjoint_Some_r. 1: eapply extended_to_trans_2; done.
       apply lookup_singleton.
     + eapply is_val_extended_to_weaken; done.
-Admitted.
+Qed.
 
-Lemma deserialize_ML_values χMLold vs :  
+Lemma deserialize_ML_values χMLold vs :
   lloc_map_inj χMLold
 → ∃ χC ζimm lvs,
     extended_to χMLold ζimm χC
@@ -233,7 +235,7 @@ Proof.
       eapply map_union_subseteq_r, extended_to_trans; done.
 Qed.
 
-Lemma deserialize_ML_block χMLold vs :  
+Lemma deserialize_ML_block χMLold vs :
   lloc_map_inj χMLold
 → ∃ χC ζimm blk,
     extended_to χMLold ζimm χC
@@ -289,7 +291,7 @@ Proof.
   1: apply H2. 1-2:done.
 Qed.
 
-Lemma deserialize_ML_heap χMLold σ : 
+Lemma deserialize_ML_heap χMLold σ :
   lloc_map_inj χMLold
 → ∃ χC ζσ ζnewimm,
     extended_to χMLold ζnewimm χC
@@ -386,7 +388,7 @@ Proof.
       rewrite <- Hk1. f_equal. eapply Hχ1; try done. eapply lookup_weaken, Hχ1; done.
 Qed.
 
-Lemma deserialize_ML_heap_extra ζMLold χMLold σ : 
+Lemma deserialize_ML_heap_extra ζMLold χMLold σ :
   lloc_map_inj χMLold
 → dom ζMLold ⊆ dom χMLold
 → (map_Forall (fun _ ℓ => σ !! ℓ = Some None) (pub_locs_in_lstore χMLold ζMLold))
@@ -406,7 +408,7 @@ Proof.
        erewrite (map_Forall_lookup_1 _ _ _ _ H3) in HH8.
        2: { eapply elem_of_dom_2 in HH1. erewrite pub_locs_in_lstore_lookup; first done; first done.
             eapply elem_of_weaken in H2; last done.
-            eapply elem_of_dom in H2; destruct H2 as [k Hk]. rewrite Hk. 
+            eapply elem_of_dom in H2; destruct H2 as [k Hk]. rewrite Hk.
             eapply lookup_weaken in Hk; first erewrite HH7 in Hk. 2: eapply HA1. done. }
        congruence. }
   do 3 eexists; split_and!; try done.

--- a/theories/interop/basics_resources.v
+++ b/theories/interop/basics_resources.v
@@ -445,8 +445,8 @@ Notation "γ ↦clos ( f , x , e )" := (lstore_own_immut γ (Bclosure f x e))%I
 
 (* Foreign block points-to *)
 
-Definition lstore_own_foreign γ dq (mut : ismut) (v : option word) : iProp Σ :=
-  lstore_own_elem γ dq (Bforeign mut v) ∗
+Definition lstore_own_foreign γ dq mut v : iProp Σ :=
+  lstore_own_elem γ dq (Bforeign (mut, v)) ∗
   match mut with
   | Mut   => γ ~ℓ~/
   | Immut => True
@@ -507,7 +507,7 @@ Proof using.
   iInduction H as [] "IH" forall "Hζ Hχ"; try (cbn; done).
   1: { iExists γ; iSplit; first done.
     iPoseProof (lstore_own_auth_get_immut
-      ζvirt γ (Bforeign Immut (Some (defs.C_intf.LitV (defs.C_intf.LitInt x))))
+      ζvirt γ (Bforeign (Immut, Some (defs.C_intf.LitV (defs.C_intf.LitInt x))))
       with "Hζ")
       as "Himm";
       try eauto.

--- a/theories/interop/basics_resources.v
+++ b/theories/interop/basics_resources.v
@@ -498,31 +498,43 @@ Lemma block_sim_of_auth (ζfreeze ζσ ζvirt : lstore) (χvirt : lloc_map) (σM
   lstore_own_auth ζvirt -∗
   b ~~ v.
 Proof using.
-Admitted.
-(*   iIntros (Hfreeze Hstorebl Hstore Hdisj H) "Hχ Hζ". *)
-(*   iDestruct (lstore_own_auth_get_immut_all with "Hζ") as "#Hζimm". *)
-(*   iInduction H as [] "IH" forall "Hζ Hχ"; cbn; try done. *)
-(*   1: iExists γ; iSplit; first done. *)
-(*   1: by iApply (lloc_own_auth_get_pub with "Hχ"). *)
-(*   1: iExists γ, lv1, lv2; iSplit; first done; iSplit. *)
-(*   3-4: iExists γ, lv; iSplit; first done; iSplit. *)
-(*   7: iExists γ; iSplit; first done. *)
-(*   1,3,5,7: *)
-(*     try iApply lstore_own_vblock_I_as_imm; *)
-(*     iApply (big_sepM_lookup with "Hζimm"); try done. *)
-(*   5: iSplit. *)
-(*   5,7,8: by iApply ("IH" with "[] [] [] Hζ Hχ"). *)
-(*   5: by iApply ("IH1" with "[] [] [] Hζ Hχ"). *)
-(*   all: simplify_eq. *)
-(*   all: apply lstore_immut_blocks_lookup_immut. *)
-(*   all: match goal with H: (_ ∪ _) !! _ = Some _ |- _ => *)
-(*       apply lookup_union_Some in H as [|]; eauto end. *)
-(*   all: destruct Hstorebl as [_ Hstorebl2]. *)
-(*   all: specialize (Hstorebl2 γ) as [Hstorebl2 _]. *)
-(*   all: destruct Hstorebl2 as (ℓ & Vs & Hχ & Hσml); [by eapply elem_of_dom_2|]. *)
-(*   all: efeed specialize Hstore; eauto; [eapply lookup_union_Some; by eauto|]. *)
-(*   all: inversion Hstore. *)
-(* Qed. *)
+  iIntros (Hfreeze Hstorebl Hstore Hdisj H) "Hχ Hζ".
+  iDestruct (lstore_own_auth_get_immut_all with "Hζ") as "#Hζimm".
+  iInduction H as [] "IH" forall "Hζ Hχ"; try (cbn; done).
+  1: { iExists γ; iSplit; first done.
+    iPoseProof (lstore_own_auth_get_immut
+      ζvirt γ (Bforeign Immut (Some (defs.C_intf.LitV (defs.C_intf.LitInt x))))
+      with "Hζ")
+      as "Himm";
+      try eauto.
+    1: { simplify_eq. apply lookup_union_Some in H as [|]; eauto.
+         destruct Hstorebl as [_ Hstorebl2].
+         specialize (Hstorebl2 γ) as [Hstorebl2 _].
+         destruct Hstorebl2 as (ℓ & Vs & Hχ & Hσml); [by eapply elem_of_dom_2|].
+         efeed specialize Hstore; eauto; [eapply lookup_union_Some; by eauto|].
+         inversion Hstore. }
+    by iPoseProof (lstore_own_immut_to_elem with "Himm") as "Himm". }
+  1: iExists γ; iSplit; first done.
+  1: by iApply (lloc_own_auth_get_pub with "Hχ").
+  1: iExists γ, lv1, lv2; iSplit; first done; iSplit.
+  3-4: iExists γ, lv; iSplit; first done; iSplit.
+  7: iExists γ; iSplit; first done.
+  1,3,5,7:
+    try iApply lstore_own_vblock_I_as_imm;
+    iApply (big_sepM_lookup with "Hζimm"); try done.
+  5: iSplit.
+  5,7,8: by iApply ("IH" with "[] [] [] Hζ Hχ").
+  5: by iApply ("IH1" with "[] [] [] Hζ Hχ").
+  all: simplify_eq.
+  all: apply lstore_immut_blocks_lookup_immut.
+  all: match goal with H: (_ ∪ _) !! _ = Some _ |- _ =>
+      apply lookup_union_Some in H as [|]; eauto end.
+  all: destruct Hstorebl as [_ Hstorebl2].
+  all: specialize (Hstorebl2 γ) as [Hstorebl2 _].
+  all: destruct Hstorebl2 as (ℓ & Vs & Hχ & Hσml); [by eapply elem_of_dom_2|].
+  all: efeed specialize Hstore; eauto; [eapply lookup_union_Some; by eauto|].
+  all: inversion Hstore.
+Qed.
 
 Lemma block_sim_arr_of_auth (ζfreeze ζσ ζvirt : lstore) (χvirt : lloc_map) (σMLvirt : store)
    vs bb :
@@ -553,24 +565,27 @@ Lemma block_sim_auth_is_val  (ζfreeze ζσ ζvirt : lstore) (χvirt : lloc_map)
   b ~~ v -∗
   ⌜is_val χvirt ζfreeze v b⌝.
 Proof using.
-Admitted.
-(*   iIntros (Hfreeze Hstorebl Hstore Hdis) "Hχ Hζ Hsim". *)
-(*   iInduction v as [[x|bo| | |]| | | |] "IH" forall (b); cbn. *)
-(*   all: try (iPure "Hsim" as Hsim; subst; iPureIntro; try econstructor; done). *)
-(*   1: {iDestruct "Hsim" as "(%γ & -> & Hsim)". *)
-(*       iPoseProof (lloc_own_pub_of with "Hχ Hsim") as "%HH". *)
-(*       iPureIntro. econstructor. done. } *)
-(*   1: iDestruct "Hsim" as "(%γ & -> & Hsim)". *)
-(*   2: iDestruct "Hsim" as "(%γ & %lv1 & %lv2 & -> & Hsim & Hlv1 & Hlv2)"; *)
-(*      iPoseProof ("IH" with "Hχ Hζ Hlv1") as "%Hr1"; *)
-(*      iPoseProof ("IH1" with "Hχ Hζ Hlv2") as "%Hr2". *)
-(*   3-4: iDestruct "Hsim" as "(%γ & %lv & -> & Hsim & Hlv)"; *)
-(*        iPoseProof ("IH" with "Hχ Hζ Hlv") as "%Hr". *)
-(*   all: try iDestruct (lstore_own_vblock_I_as_imm with "Hsim") as "Hsim". *)
-(*   1-4: unshelve iPoseProof (lstore_own_immut_of with "Hζ Hsim") as "[%HH _]". *)
-(*   all: iPureIntro; econstructor; eauto; by simplify_map_eq. *)
-(* Qed. *)
-(**)
+  iIntros (Hfreeze Hstorebl Hstore Hdis) "Hχ Hζ Hsim".
+  iInduction v as [[x|bo| | | n |]| | | |] "IH" forall (b).
+  all: try (iPure "Hsim" as Hsim; subst; iPureIntro; try econstructor; done).
+  1: { iDestruct "Hsim" as "(%γ & -> & Hsim)".
+    iPoseProof (lstore_own_elem_to_immut with "Hsim") as "Hsim"; first done.
+    iPoseProof (lstore_own_immut_of with "Hζ Hsim") as "[%H1 %H2]".
+    iPureIntro. econstructor. by simplify_map_eq. }
+  1: {iDestruct "Hsim" as "(%γ & -> & Hsim)".
+      iPoseProof (lloc_own_pub_of with "Hχ Hsim") as "%HH".
+      iPureIntro. econstructor. done. }
+  1: iDestruct "Hsim" as "(%γ & -> & Hsim)".
+  2: iDestruct "Hsim" as "(%γ & %lv1 & %lv2 & -> & Hsim & Hlv1 & Hlv2)";
+     iPoseProof ("IH" with "Hχ Hζ Hlv1") as "%Hr1";
+     iPoseProof ("IH1" with "Hχ Hζ Hlv2") as "%Hr2".
+  3-4: iDestruct "Hsim" as "(%γ & %lv & -> & Hsim & Hlv)";
+       iPoseProof ("IH" with "Hχ Hζ Hlv") as "%Hr".
+  all: try iDestruct (lstore_own_vblock_I_as_imm with "Hsim") as "Hsim".
+  1-4: unshelve iPoseProof (lstore_own_immut_of with "Hζ Hsim") as "[%HH _]".
+  all: iPureIntro; econstructor; eauto; by simplify_map_eq.
+Qed.
+
 Lemma block_sim_arr_auth_is_val (ζfreeze ζσ ζvirt : lstore) (χvirt : lloc_map) (σMLvirt : store)
    vs bb :
   ζfreeze = ζσ ∪ ζvirt →

--- a/theories/interop/basics_resources.v
+++ b/theories/interop/basics_resources.v
@@ -4,6 +4,7 @@ From transfinite.base_logic.lib Require Import ghost_map ghost_var gen_heap gset
 From iris.proofmode Require Import proofmode.
 From melocoton Require Import named_props iris_extra.
 From melocoton.ml_lang Require Import lang.
+From melocoton.c_interface Require Import defs.
 From melocoton.interop Require Export basics.
 
 Class wrapperBasicsGpre `{SI: indexT} Σ := WrapperBasicsGpre {
@@ -464,7 +465,7 @@ Fixpoint block_sim (v : val) (lv : lval) : iProp Σ := match v with
   | ML_lang.LitV (ML_lang.LitBool b) => ⌜lv = (Lint (if b then 1 else 0))⌝
   | ML_lang.LitV ML_lang.LitUnit => ⌜lv = (Lint 0)⌝
   | ML_lang.LitV (ML_lang.LitBoxedInt i) => ∃ γ,
-      ⌜lv = (Lloc γ)⌝ ∗ γ ↦foreignO[Immut] (Some (defs.C_intf.LitV (defs.C_intf.LitInt i)))
+      ⌜lv = (Lloc γ)⌝ ∗ γ ↦foreignO[Immut] (Some (C_intf.LitV (C_intf.LitInt i)))
   | ML_lang.LitV (ML_lang.LitLoc ℓ) => ∃ γ, ⌜lv = (Lloc γ)⌝ ∗ γ ~ℓ~ ℓ
   | ML_lang.LitV (ML_lang.LitForeign γ) => ⌜lv = (Lloc γ)⌝
   | ML_lang.PairV v1 v2 => ∃ γ lv1 lv2,

--- a/theories/interop/basics_resources.v
+++ b/theories/interop/basics_resources.v
@@ -38,9 +38,6 @@ Context `{!wrapperBasicsG Σ}.
 Definition lloc_own_priv (γ : lloc) : iProp Σ :=
   γ ↪[wrapperG_γχvirt] LlocPrivate.
 
-Definition lloc_own_priv_persistent (γ : lloc) : iProp Σ :=
-  γ ↪[wrapperG_γχvirt]□ LlocPrivate.
-
 Definition lloc_own_pub (γ : lloc) (ℓ : loc) : iProp Σ :=
   gset_bij_own_elem wrapperG_γχbij γ ℓ.
 
@@ -56,8 +53,6 @@ Notation "γ ~ℓ~ ℓ" := (lloc_own_pub γ ℓ)
   (at level 20, format "γ  ~ℓ~  ℓ").
 Notation "γ ~ℓ~/" := (lloc_own_priv γ)
   (at level 20, format "γ  ~ℓ~/").
-Notation "γ ~ℓ~/☐" := (lloc_own_priv_persistent γ)
-  (at level 20, format "γ  ~ℓ~/☐").
 
 Lemma lloc_own_pub_inj γ1 γ2 ℓ1 ℓ2 :
   γ1 ~ℓ~ ℓ1 -∗ γ2 ~ℓ~ ℓ2 -∗ ⌜γ1 = γ2 ↔ ℓ1 = ℓ2⌝.
@@ -451,7 +446,11 @@ Notation "γ ↦clos ( f , x , e )" := (lstore_own_immut γ (Bclosure f x e))%I
 (* Foreign block points-to *)
 
 Definition lstore_own_foreign γ dq (mut : ismut) (v : option word) : iProp Σ :=
-  lstore_own_elem γ dq (Bforeign mut v) ∗ γ ~ℓ~/☐.
+  lstore_own_elem γ dq (Bforeign mut v) ∗
+  match mut with
+  | Mut   => γ ~ℓ~/
+  | Immut => True
+  end.
 
 Notation "γ ↦foreignO[ mut ]{ dq } a" := (lstore_own_foreign γ dq mut a)%I
   (at level 20, format "γ  ↦foreignO[ mut ]{ dq }  a") : bi_scope.
@@ -518,9 +517,8 @@ Proof using.
          destruct Hstorebl2 as (ℓ & Vs & Hχ & Hσml); [by eapply elem_of_dom_2|].
          efeed specialize Hstore; eauto; [eapply lookup_union_Some; by eauto|].
          inversion Hstore. }
-    iSplit.
-    - by iPoseProof (lstore_own_immut_to_elem with "Himm") as "Himm".
-    - admit. }
+    iSplit; try eauto.
+    by iPoseProof (lstore_own_immut_to_elem with "Himm") as "Himm". }
   1: iExists γ; iSplit; first done.
   1: by iApply (lloc_own_auth_get_pub with "Hχ").
   1: iExists γ, lv1, lv2; iSplit; first done; iSplit.
@@ -541,7 +539,7 @@ Proof using.
   all: destruct Hstorebl2 as (ℓ & Vs & Hχ & Hσml); [by eapply elem_of_dom_2|].
   all: efeed specialize Hstore; eauto; [eapply lookup_union_Some; by eauto|].
   all: inversion Hstore.
-Admitted.
+Qed.
 
 Lemma block_sim_arr_of_auth (ζfreeze ζσ ζvirt : lstore) (χvirt : lloc_map) (σMLvirt : store)
    vs bb :

--- a/theories/interop/hybrid_ghost_heap.v
+++ b/theories/interop/hybrid_ghost_heap.v
@@ -147,14 +147,15 @@ Proof using.
   - eapply is_store_expose_lloc; eauto.
 Qed.
 
-Lemma lstore_hybrid_repr_freeze_block χ ζfreeze σ ζ γ bb :
+Lemma lstore_hybrid_repr_freeze_block χ ζfreeze σ ζ γ b1 b2 :
+  freeze_block b1 b2 →
   χ !! γ = Some LlocPrivate →
-  ζ !! γ = Some (Bvblock (Mut, bb)) →
+  ζ !! γ = Some b1 →
   lstore_hybrid_repr χ ζfreeze σ ζ →
-  lstore_hybrid_repr χ (<[γ:=Bvblock (Immut, bb)]> ζfreeze) σ
-    (<[γ:=Bvblock (Immut, bb)]> ζ).
+  lstore_hybrid_repr χ (<[γ:=b2]> ζfreeze) σ
+    (<[γ:=b2]> ζ).
 Proof using.
-  intros ? ? (ζσ&->&?&?&?). exists ζσ. split_and!; eauto.
+  intros Hfreeze ? ? (ζσ&->&?&?&?). exists ζσ. split_and!; eauto.
   - rewrite insert_union_r. 1: done. eapply map_disjoint_Some_r; eauto.
   - apply map_disjoint_insert_r. split; last done. by eapply map_disjoint_Some_l.
   - eapply is_store_freeze_lloc; eauto.
@@ -366,25 +367,29 @@ Proof using.
   { eapply expose_llocs_trans; first done. eapply expose_llocs_insert; eauto. }
 Qed.
 
-Lemma hgh_freeze_block χ σ ζ γ bb :
+Lemma hgh_freeze_block χ σ ζ γ b1 b2:
+  freeze_block b1 b2 →
   HGH χ (Some σ) ζ -∗
-  lstore_own_elem γ (DfracOwn 1) (Bvblock (Mut, bb)) -∗
+  lstore_own_elem γ (DfracOwn 1) b1 -∗
   γ ~ℓ~/
   ==∗
   HGH χ (Some σ) ζ ∗
-  lstore_own_elem γ (DfracOwn 1) (Bvblock (Immut, bb)) ∗
+  lstore_own_elem γ (DfracOwn 1) b2 ∗
   γ ~ℓ~/.
 Proof using.
-  iIntros "H Hγ Hfresh". iNamed "H". iNamed "HGHσo".
+  (* TODO: Fix this proof as it does not work with freeze_block_refl *)
+  iIntros (Hfreeze) "H Hγ Hfresh".
+  iNamed "H". iNamed "HGHσo".
   iDestruct (lstore_own_elem_of with "HGHζ Hγ") as %?.
   iDestruct (lloc_own_priv_of with "HGHχ Hfresh") as %?.
+  assert (mutability b1 = Mut). { destruct Hfreeze; easy. }
   iDestruct (lstore_own_elem_to_mut with "Hγ") as "Hγ"; first done.
-  iMod (lstore_own_update _ _ _ (Bvblock (Immut, bb)) with "HGHζ Hγ") as "(HGHζ & Hγ)".
+  iMod (lstore_own_update _ _ _ b2 with "HGHζ Hγ") as "(HGHζ & Hγ)".
   iModIntro. iFrame "Hγ Hfresh". rewrite /HGH /named. iExists _, _. iFrame.
   iSplit. 2: iSplit.
   2: { rewrite pub_locs_in_lstore_insert_existing; eauto. by eapply elem_of_dom_2. }
   all: iPureIntro; eauto.
-  { exists (<[γ:=Bvblock (Immut, bb)]> ζfreeze). split.
+  { exists (<[γ:=b2]> ζfreeze). split.
     { eapply freeze_lstore_freeze_lloc; eauto.
       by eapply lstore_hybrid_repr_lookup_lloc. }
     { eapply lstore_hybrid_repr_freeze_block; eauto. } }
@@ -436,8 +441,7 @@ Lemma hgh_lookup_vblock χ σo ζ γ dq m bb :
   ⌜∃ m', (m' = Immut → m = Immut) ∧ ζ !! γ = Some (Bvblock (m', bb))⌝.
 Proof using.
   iIntros "H Hγ". iDestruct (hgh_lookup_block with "H Hγ") as %(?&Hfrz&?).
-  inversion Hfrz; subst; eauto. iPureIntro; eexists. split; last by eauto.
-  congruence.
+  inversion Hfrz; subst; eauto.
 Qed.
 
 Lemma hgh_modify_block χ σ ζ γ blk blk' :

--- a/theories/interop/hybrid_ghost_heap.v
+++ b/theories/interop/hybrid_ghost_heap.v
@@ -377,12 +377,11 @@ Lemma hgh_freeze_block χ σ ζ γ b1 b2:
   lstore_own_elem γ (DfracOwn 1) b2 ∗
   γ ~ℓ~/.
 Proof using.
-  (* TODO: Fix this proof as it does not work with freeze_block_refl *)
   iIntros (Hfreeze) "H Hγ Hfresh".
-  iNamed "H". iNamed "HGHσo".
+  destruct (mutability b1) eqn:Heq.
+  - iNamed "H". iNamed "HGHσo".
   iDestruct (lstore_own_elem_of with "HGHζ Hγ") as %?.
   iDestruct (lloc_own_priv_of with "HGHχ Hfresh") as %?.
-  assert (mutability b1 = Mut). { destruct Hfreeze; easy. }
   iDestruct (lstore_own_elem_to_mut with "Hγ") as "Hγ"; first done.
   iMod (lstore_own_update _ _ _ b2 with "HGHζ Hγ") as "(HGHζ & Hγ)".
   iModIntro. iFrame "Hγ Hfresh". rewrite /HGH /named. iExists _, _. iFrame.
@@ -393,6 +392,7 @@ Proof using.
     { eapply freeze_lstore_freeze_lloc; eauto.
       by eapply lstore_hybrid_repr_lookup_lloc. }
     { eapply lstore_hybrid_repr_freeze_block; eauto. } }
+  - destruct Hfreeze; try inversion Heq. by iFrame.
 Qed.
 
 Lemma hgh_alloc_block χ σ ζ γ blk :
@@ -439,6 +439,15 @@ Lemma hgh_lookup_vblock χ σo ζ γ dq m bb :
   HGH χ σo ζ -∗
   lstore_own_elem γ dq (Bvblock (m, bb)) -∗
   ⌜∃ m', (m' = Immut → m = Immut) ∧ ζ !! γ = Some (Bvblock (m', bb))⌝.
+Proof using.
+  iIntros "H Hγ". iDestruct (hgh_lookup_block with "H Hγ") as %(?&Hfrz&?).
+  inversion Hfrz; subst; eauto.
+Qed.
+
+Lemma hgh_lookup_foreign χ σo ζ γ dq m bb :
+  HGH χ σo ζ -∗
+  lstore_own_elem γ dq (Bforeign m bb) -∗
+  ⌜∃ m', (m' = Immut → m = Immut) ∧ ζ !! γ = Some (Bforeign m' bb)⌝.
 Proof using.
   iIntros "H Hγ". iDestruct (hgh_lookup_block with "H Hγ") as %(?&Hfrz&?).
   inversion Hfrz; subst; eauto.

--- a/theories/interop/hybrid_ghost_heap.v
+++ b/theories/interop/hybrid_ghost_heap.v
@@ -446,8 +446,8 @@ Qed.
 
 Lemma hgh_lookup_foreign χ σo ζ γ dq m bb :
   HGH χ σo ζ -∗
-  lstore_own_elem γ dq (Bforeign m bb) -∗
-  ⌜∃ m', (m' = Immut → m = Immut) ∧ ζ !! γ = Some (Bforeign m' bb)⌝.
+  lstore_own_elem γ dq (Bforeign (m, bb)) -∗
+  ⌜∃ m', (m' = Immut → m = Immut) ∧ ζ !! γ = Some (Bforeign (m', bb))⌝.
 Proof using.
   iIntros "H Hγ". iDestruct (hgh_lookup_block with "H Hγ") as %(?&Hfrz&?).
   inversion Hfrz; subst; eauto.

--- a/theories/interop/lang.v
+++ b/theories/interop/lang.v
@@ -338,9 +338,9 @@ Inductive c_prim_step :
       θC' !! γ = Some a →
       Y (CLocV a) (WrapstateC χC' ζC' θC' (rootsC ρc)) mem') →
     c_prim_step Pallocforeign [] ρc mem Y
-  | PrimReadForeignS w γ aforeign ρc mem Y :
+  | PrimReadForeignS w γ m aforeign ρc mem Y :
     repr_lval (θC ρc) (Lloc γ) w →
-    (ζC ρc) !! γ = Some (Bforeign Mut (Some aforeign)) →
+    (ζC ρc) !! γ = Some (Bforeign m (Some aforeign)) →
     Y aforeign ρc mem →
     c_prim_step Preadforeign [w] ρc mem Y
   | PrimWriteForeignS w γ aforeigno aforeign' ζC' ρc mem Y :

--- a/theories/interop/lang.v
+++ b/theories/interop/lang.v
@@ -331,22 +331,22 @@ Inductive c_prim_step :
     (∀ γ χC' ζC' θC' a mem',
       χC ρc !! γ = None →
       χC' = <[ γ := LlocPrivate ]> (χC ρc) →
-      ζC' = <[ γ := Bforeign Mut None ]> (ζC ρc) →
+      ζC' = <[ γ := Bforeign (Mut, None) ]> (ζC ρc) →
       GC_correct ζC' θC' →
       repr θC' roots privmem mem' →
       roots_are_live θC' roots →
       θC' !! γ = Some a →
       Y (CLocV a) (WrapstateC χC' ζC' θC' (rootsC ρc)) mem') →
     c_prim_step Pallocforeign [] ρc mem Y
-  | PrimReadForeignS w γ m aforeign ρc mem Y :
+  | PrimReadForeignS w γ mut aforeign ρc mem Y :
     repr_lval (θC ρc) (Lloc γ) w →
-    (ζC ρc) !! γ = Some (Bforeign m (Some aforeign)) →
+    (ζC ρc) !! γ = Some (Bforeign (mut, Some aforeign)) →
     Y aforeign ρc mem →
     c_prim_step Preadforeign [w] ρc mem Y
   | PrimWriteForeignS w γ aforeigno aforeign' ζC' ρc mem Y :
     repr_lval (θC ρc) (Lloc γ) w →
-    (ζC ρc) !! γ = Some (Bforeign Mut aforeigno) →
-    ζC' = <[ γ := Bforeign Mut (Some aforeign') ]> (ζC ρc) →
+    (ζC ρc) !! γ = Some (Bforeign (Mut, aforeigno)) →
+    ζC' = <[ γ := Bforeign (Mut, Some aforeign') ]> (ζC ρc) →
     Y (CIntV 0) (WrapstateC (χC ρc) ζC' (θC ρc) (rootsC ρc)) mem →
     c_prim_step Pwriteforeign [w; aforeign'] ρc mem Y.
 
@@ -404,7 +404,7 @@ Proof.
     pose proof (is_fresh fresh_src) as ((HFχ&HFθ)%not_elem_of_union&HFζ)%not_elem_of_union.
     specialize (H4 γ
                  (<[ γ := LlocPrivate ]> (χC ρc))
-                 (<[ γ := Bforeign Mut None ]> (ζC ρc))
+                 (<[ γ := Bforeign (Mut, None) ]> (ζC ρc))
                  (<[ γ := w ]> (θC ρc))
                  w mem).
     do 3 eexists. eapply H4; eauto.

--- a/theories/interop/lang.v
+++ b/theories/interop/lang.v
@@ -331,7 +331,7 @@ Inductive c_prim_step :
     (∀ γ χC' ζC' θC' a mem',
       χC ρc !! γ = None →
       χC' = <[ γ := LlocPrivate ]> (χC ρc) →
-      ζC' = <[ γ := Bforeign None ]> (ζC ρc) →
+      ζC' = <[ γ := Bforeign Mut None ]> (ζC ρc) →
       GC_correct ζC' θC' →
       repr θC' roots privmem mem' →
       roots_are_live θC' roots →
@@ -340,13 +340,13 @@ Inductive c_prim_step :
     c_prim_step Pallocforeign [] ρc mem Y
   | PrimReadForeignS w γ aforeign ρc mem Y :
     repr_lval (θC ρc) (Lloc γ) w →
-    (ζC ρc) !! γ = Some (Bforeign (Some aforeign)) →
+    (ζC ρc) !! γ = Some (Bforeign Mut (Some aforeign)) →
     Y aforeign ρc mem →
     c_prim_step Preadforeign [w] ρc mem Y
   | PrimWriteForeignS w γ aforeigno aforeign' ζC' ρc mem Y :
     repr_lval (θC ρc) (Lloc γ) w →
-    (ζC ρc) !! γ = Some (Bforeign aforeigno) →
-    ζC' = <[ γ := Bforeign (Some aforeign') ]> (ζC ρc) →
+    (ζC ρc) !! γ = Some (Bforeign Mut aforeigno) →
+    ζC' = <[ γ := Bforeign Mut (Some aforeign') ]> (ζC ρc) →
     Y (CIntV 0) (WrapstateC (χC ρc) ζC' (θC ρc) (rootsC ρc)) mem →
     c_prim_step Pwriteforeign [w; aforeign'] ρc mem Y.
 
@@ -404,7 +404,7 @@ Proof.
     pose proof (is_fresh fresh_src) as ((HFχ&HFθ)%not_elem_of_union&HFζ)%not_elem_of_union.
     specialize (H4 γ
                  (<[ γ := LlocPrivate ]> (χC ρc))
-                 (<[ γ := Bforeign None ]> (ζC ρc))
+                 (<[ γ := Bforeign Mut None ]> (ζC ρc))
                  (<[ γ := w ]> (θC ρc))
                  w mem).
     do 3 eexists. eapply H4; eauto.

--- a/theories/interop/prims_proto.v
+++ b/theories/interop/prims_proto.v
@@ -148,29 +148,29 @@ Definition alloc_foreign_proto : C_proto :=
   !! θ
   {{ GC θ }}
     "alloc_foreign" with []
-  {{ θ' γ w, RET w; GC θ' ∗ γ ↦foreignO None ∗ ⌜repr_lval θ' (Lloc γ) w⌝ }}.
+  {{ θ' γ w, RET w; GC θ' ∗ γ ↦foreignO[Mut] None ∗ ⌜repr_lval θ' (Lloc γ) w⌝ }}.
 
 Definition write_foreign_proto : C_proto :=
   !! θ γ w wo w'
   {{
      "HGC" ∷ GC θ ∗
      "%Hreprw" ∷ ⌜repr_lval θ (Lloc γ) w⌝ ∗
-     "Hpto" ∷ γ ↦foreignO wo
+     "Hpto" ∷ γ ↦foreignO[Mut] wo
   }}
     "write_foreign" with [ w; w' ]
   {{ RET (C_intf.LitV (C_intf.LitInt 0));
-     GC θ ∗ γ ↦foreign w'
+     GC θ ∗ γ ↦foreign[Mut] w'
   }}.
 
 Definition read_foreign_proto : C_proto :=
-  !! θ γ w w' dq
+  !! θ γ w w' m dq
   {{
      "HGC" ∷ GC θ ∗
      "%Hreprw" ∷ ⌜repr_lval θ (Lloc γ) w⌝ ∗
-     "Hpto" ∷ γ ↦foreign{dq} w'
+     "Hpto" ∷ γ ↦foreign[m]{dq} w'
   }}
     "read_foreign" with [ w ]
-  {{ RET w'; GC θ ∗ γ ↦foreign{dq} w' }}.
+  {{ RET w'; GC θ ∗ γ ↦foreign[m]{dq} w' }}.
 
 Definition callback_proto (Ψ : ML_proto) : C_proto :=
   !! θ w γ w' lv' v' f x e Φ'

--- a/theories/interop/update_laws.v
+++ b/theories/interop/update_laws.v
@@ -55,7 +55,19 @@ Lemma freeze_to_immut γ lvs θ :
 Proof using.
   iIntros "(HGC & Hγ)". iNamed "HGC".
   iDestruct (lstore_own_vblock_F_as_mut with "Hγ") as "([Hmtζ _] & Hmtfresh)".
-  iMod (hgh_freeze_block with "GCHGH Hmtζ Hmtfresh") as "(GCHGH & Hmtζ & Hmtfresh)".
+  assert (is_mut_of (Bvblock (Mut, lvs)) (Bvblock (Immut, lvs))) as Hmut.
+    { econstructor. }
+  iMod (hgh_freeze_block _ _ _ _ _ _ Hmut with "GCHGH Hmtζ Hmtfresh") as "(GCHGH & Hmtζ & Hmtfresh)".
+  iModIntro. iSplitR "Hmtζ Hmtfresh"; last by iFrame; eauto.
+  rewrite /GC /named. repeat iExists _. iFrame; eauto.
+Qed.
+
+Lemma freeze_foreign_to_immut γ θ b :
+  ⊢ GC θ ∗ γ ↦foreign[Mut] b ==∗
+    GC θ ∗ γ ↦foreign[Immut] b.
+Proof.
+  iIntros "(HGC & Hγ)".
+  iMod (hgh_freeze_block with "GCHGH Hγ") as "(GCHGH & Hmtζ & Hmtfresh)".
   iModIntro. iSplitR "Hmtζ Hmtfresh"; last by iFrame; eauto.
   rewrite /GC /named. repeat iExists _. iFrame; eauto.
 Qed.

--- a/theories/interop/update_laws.v
+++ b/theories/interop/update_laws.v
@@ -67,7 +67,7 @@ Lemma freeze_foreign_to_immut γ θ b :
     GC θ ∗ γ ↦foreign[Immut] b.
 Proof.
   iIntros "(HGC & [Hγ1 Hγ2])". iNamed "HGC".
-  assert (freeze_block (Bforeign Mut (Some b)) (Bforeign Immut (Some b))) as Hfreeze.
+  assert (freeze_block (Bforeign (Mut, Some b)) (Bforeign (Immut, Some b))) as Hfreeze.
     { econstructor. }
   iMod (hgh_freeze_block _ _ _ _ _ _ Hfreeze with "GCHGH Hγ1 Hγ2") as "(GCHGH & Hmtζ & Hmtfresh)".
   iModIntro. iSplitR "Hmtζ Hmtfresh"; last by iFrame; eauto.

--- a/theories/interop/update_laws.v
+++ b/theories/interop/update_laws.v
@@ -55,9 +55,9 @@ Lemma freeze_to_immut γ lvs θ :
 Proof using.
   iIntros "(HGC & Hγ)". iNamed "HGC".
   iDestruct (lstore_own_vblock_F_as_mut with "Hγ") as "([Hmtζ _] & Hmtfresh)".
-  assert (is_mut_of (Bvblock (Mut, lvs)) (Bvblock (Immut, lvs))) as Hmut.
+  assert (freeze_block (Bvblock (Mut, lvs)) (Bvblock (Immut, lvs))) as Hfreeze.
     { econstructor. }
-  iMod (hgh_freeze_block _ _ _ _ _ _ Hmut with "GCHGH Hmtζ Hmtfresh") as "(GCHGH & Hmtζ & Hmtfresh)".
+  iMod (hgh_freeze_block _ _ _ _ _ _ Hfreeze with "GCHGH Hmtζ Hmtfresh") as "(GCHGH & Hmtζ & Hmtfresh)".
   iModIntro. iSplitR "Hmtζ Hmtfresh"; last by iFrame; eauto.
   rewrite /GC /named. repeat iExists _. iFrame; eauto.
 Qed.
@@ -66,11 +66,11 @@ Lemma freeze_foreign_to_immut γ θ b :
   ⊢ GC θ ∗ γ ↦foreign[Mut] b ==∗
     GC θ ∗ γ ↦foreign[Immut] b.
 Proof.
-  iIntros "(HGC & Hγ)".
-  iMod (hgh_freeze_block with "GCHGH Hγ") as "(GCHGH & Hmtζ & Hmtfresh)".
-  iModIntro. iSplitR "Hmtζ Hmtfresh"; last by iFrame; eauto.
-  rewrite /GC /named. repeat iExists _. iFrame; eauto.
-Qed.
+  iIntros "(HGC & Hγ)". iNamed "HGC".
+  (* iMod (hgh_freeze_block _ _ _ _ _ _ _ with "GCHGH Hγ") as "(GCHGH & Hmtζ & Hmtfresh)". *)
+  (* iModIntro. iSplitR "Hmtζ Hmtfresh"; last by iFrame; eauto. *)
+  (* rewrite /GC /named. repeat iExists _. iFrame; eauto. *)
+Admitted.
 
 Lemma update_root θ (l:loc) v E :
   GC θ ∗ l ↦roots v -∗

--- a/theories/interop/update_laws.v
+++ b/theories/interop/update_laws.v
@@ -66,11 +66,13 @@ Lemma freeze_foreign_to_immut γ θ b :
   ⊢ GC θ ∗ γ ↦foreign[Mut] b ==∗
     GC θ ∗ γ ↦foreign[Immut] b.
 Proof.
-  iIntros "(HGC & Hγ)". iNamed "HGC".
-  (* iMod (hgh_freeze_block _ _ _ _ _ _ _ with "GCHGH Hγ") as "(GCHGH & Hmtζ & Hmtfresh)". *)
-  (* iModIntro. iSplitR "Hmtζ Hmtfresh"; last by iFrame; eauto. *)
-  (* rewrite /GC /named. repeat iExists _. iFrame; eauto. *)
-Admitted.
+  iIntros "(HGC & [Hγ1 Hγ2])". iNamed "HGC".
+  assert (freeze_block (Bforeign Mut (Some b)) (Bforeign Immut (Some b))) as Hfreeze.
+    { econstructor. }
+  iMod (hgh_freeze_block _ _ _ _ _ _ Hfreeze with "GCHGH Hγ1 Hγ2") as "(GCHGH & Hmtζ & Hmtfresh)".
+  iModIntro. iSplitR "Hmtζ Hmtfresh"; last by iFrame; eauto.
+  rewrite /GC /named. repeat iExists _. iFrame; eauto.
+Qed.
 
 Lemma update_root θ (l:loc) v E :
   GC θ ∗ l ↦roots v -∗

--- a/theories/interop/wp_prims/alloc_foreign.v
+++ b/theories/interop/wp_prims/alloc_foreign.v
@@ -67,7 +67,7 @@ Proof using.
   iApply wp_value; first done.
   iApply "Hcont". iFrame.
   iApply ("Cont" $! θC' γ with "[-]"); try done.
-  iFrame "Hpto". iSplit; last by eauto.
+  iFrame. iSplit; last by eauto.
   rewrite /GC /named.
   iExists _, _, σMLvirt, _, _. iFrame; eauto.
 Qed.

--- a/theories/interop/wp_prims/alloc_foreign.v
+++ b/theories/interop/wp_prims/alloc_foreign.v
@@ -23,54 +23,53 @@ Import mlanguage.
 
 Lemma alloc_foreign_correct e : |- wrap_prog e :: alloc_foreign_proto.
 Proof using.
-Admitted.
-(*   iIntros (? ? ? ?) "H". unfold mprogwp. iNamedProto "H". *)
-(*   iSplit; first done. *)
-(*   iIntros (Φ') "Hb Hcont". iApply wp_wrap_call; first done. cbn [snd]. *)
-(*   rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre. *)
-(*   iIntros "%σ Hσ". cbn -[wrap_prog]. *)
-(*   SI_at_boundary. SI_GC_agree. *)
-(*   iAssert (⌜∀ k lv, roots_m !! k = Some lv → *)
-(*             ∃ w, mem !! k = Some (Storing w) ∧ repr_lval (θC ρc) lv w⌝)%I as "%Hroots". *)
-(*   1: { iIntros (kk vv Hroots). *)
-(*        iPoseProof (big_sepM_lookup with "GCrootspto") as "(%wr & Hwr & %Hw2)"; first done. *)
-(*        iExists wr. iSplit; last done. iApply (gen_heap_valid with "HσC Hwr"). } *)
-(*   destruct (make_repr (θC ρc) roots_m mem) as [privmem Hpriv]; try done. *)
-(**)
-(*   assert (GC_correct (ζC ρc) (θC ρc)) as HGC'. *)
-(*   { eapply GC_correct_transport_rev; last done; done. } *)
-(**)
-(*   iApply wp_pre_cases_c_prim; [done..|]. *)
-(*   iExists (λ '(e', σ'), ∃ γ χC' ζC' θC' (aret:loc) mem', *)
-(*       χC ρc !! γ = None ∧ *)
-(*       χC' = <[ γ := LlocPrivate ]> (χC ρc) ∧ *)
-(*       ζC' = <[ γ := Bforeign None ]> (ζC ρc) ∧ *)
-(*       GC_correct ζC' θC' ∧ *)
-(*       repr θC' roots_m privmem mem' ∧ *)
-(*       roots_are_live θC' roots_m ∧ *)
-(*       θC' !! γ = Some aret ∧ *)
-(*       e' = WrSE (ExprV (# aret)) ∧ *)
-(*       σ' = CState (WrapstateC χC' ζC' θC' (rootsC ρc)) mem'). *)
-(*   iSplit. { iPureIntro. econstructor; naive_solver. } *)
-(*   iIntros (? ? ? (γ & χC' & ζC' & θC' & aret & mem' & *)
-(*                   HγNone & -> & -> & HGCOK' & Hrepr' & Hrootslive' & ?)). *)
-(*   destruct_and!; simplify_eq. *)
-(**)
-(*   iMod (hgh_alloc_block with "GCHGH") as "(GCHGH & Hpto & Hfresh)"; first eassumption. *)
-(*   iMod (set_to_none _ _ _ _ Hpriv with "HσC GCrootspto") as "(HσC&GCrootspto)". *)
-(*   iMod (set_to_some _ _ _ _ Hrepr' with "HσC GCrootspto") as "(HσC&GCrootspto)". *)
-(*   iMod (ghost_var_update_halves with "GCζ SIζ") as "(GCζ&SIζ)". *)
-(*   iMod (ghost_var_update_halves with "GCχ SIχ") as "(GCχ&SIχ)". *)
-(*   iMod (ghost_var_update_halves with "GCθ SIθ") as "(GCθ&SIθ)". *)
-(**)
-(*   do 3 iModIntro. iFrame. cbn -[wrap_prog]. *)
-(*   iSplitL "SIinit". { iExists false. iFrame. } *)
-(*   iApply wp_value; first done. *)
-(*   iApply "Hcont". iFrame. *)
-(*   iApply ("Cont" $! θC' γ with "[-]"); try done. *)
-(*   iFrame "Hpto". iSplit; last by eauto. *)
-(*   rewrite /GC /named. *)
-(*   iExists _, _, σMLvirt, _, _. iFrame; eauto. *)
-(* Qed. *)
-(**)
+  iIntros (? ? ? ?) "H". unfold mprogwp. iNamedProto "H".
+  iSplit; first done.
+  iIntros (Φ') "Hb Hcont". iApply wp_wrap_call; first done. cbn [snd].
+  rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre.
+  iIntros "%σ Hσ".
+  SI_at_boundary. SI_GC_agree.
+  iAssert (⌜∀ k lv, roots_m !! k = Some lv →
+            ∃ w, mem !! k = Some (Storing w) ∧ repr_lval (θC ρc) lv w⌝)%I as "%Hroots".
+  1: { iIntros (kk vv Hroots).
+       iPoseProof (big_sepM_lookup with "GCrootspto") as "(%wr & Hwr & %Hw2)"; first done.
+       iExists wr. iSplit; last done. iApply (gen_heap_valid with "HσC Hwr"). }
+  destruct (make_repr (θC ρc) roots_m mem) as [privmem Hpriv]; try done.
+
+  assert (GC_correct (ζC ρc) (θC ρc)) as HGC'.
+  { eapply GC_correct_transport_rev; last done; done. }
+
+  iApply wp_pre_cases_c_prim; [done..|].
+  iExists (λ '(e', σ'), ∃ γ χC' ζC' θC' (aret:loc) mem',
+      χC ρc !! γ = None ∧
+      χC' = <[ γ := LlocPrivate ]> (χC ρc) ∧
+      ζC' = <[ γ := Bforeign Mut None ]> (ζC ρc) ∧
+      GC_correct ζC' θC' ∧
+      repr θC' roots_m privmem mem' ∧
+      roots_are_live θC' roots_m ∧
+      θC' !! γ = Some aret ∧
+      e' = WrSE (ExprV (# aret)) ∧
+      σ' = CState (WrapstateC χC' ζC' θC' (rootsC ρc)) mem').
+  iSplit. { iPureIntro. econstructor; naive_solver. }
+  iIntros (? ? ? (γ & χC' & ζC' & θC' & aret & mem' &
+                  HγNone & -> & -> & HGCOK' & Hrepr' & Hrootslive' & ?)).
+  destruct_and!; simplify_eq.
+
+  iMod (hgh_alloc_block with "GCHGH") as "(GCHGH & Hpto & Hfresh)"; first eassumption.
+  iMod (set_to_none _ _ _ _ Hpriv with "HσC GCrootspto") as "(HσC&GCrootspto)".
+  iMod (set_to_some _ _ _ _ Hrepr' with "HσC GCrootspto") as "(HσC&GCrootspto)".
+  iMod (ghost_var_update_halves with "GCζ SIζ") as "(GCζ&SIζ)".
+  iMod (ghost_var_update_halves with "GCχ SIχ") as "(GCχ&SIχ)".
+  iMod (ghost_var_update_halves with "GCθ SIθ") as "(GCθ&SIθ)".
+
+  do 3 iModIntro. iFrame.
+  iSplitL "SIinit". { iExists false. iFrame. }
+  iApply wp_value; first done.
+  iApply "Hcont". iFrame.
+  iApply ("Cont" $! θC' γ with "[-]"); try done.
+  iFrame "Hpto". iSplit; last by eauto.
+  rewrite /GC /named.
+  iExists _, _, σMLvirt, _, _. iFrame; eauto.
+Qed.
+
 End Laws.

--- a/theories/interop/wp_prims/alloc_foreign.v
+++ b/theories/interop/wp_prims/alloc_foreign.v
@@ -43,7 +43,7 @@ Proof using.
   iExists (λ '(e', σ'), ∃ γ χC' ζC' θC' (aret:loc) mem',
       χC ρc !! γ = None ∧
       χC' = <[ γ := LlocPrivate ]> (χC ρc) ∧
-      ζC' = <[ γ := Bforeign Mut None ]> (ζC ρc) ∧
+      ζC' = <[ γ := Bforeign (Mut, None) ]> (ζC ρc) ∧
       GC_correct ζC' θC' ∧
       repr θC' roots_m privmem mem' ∧
       roots_are_live θC' roots_m ∧

--- a/theories/interop/wp_prims/alloc_foreign.v
+++ b/theories/interop/wp_prims/alloc_foreign.v
@@ -23,53 +23,54 @@ Import mlanguage.
 
 Lemma alloc_foreign_correct e : |- wrap_prog e :: alloc_foreign_proto.
 Proof using.
-  iIntros (? ? ? ?) "H". unfold mprogwp. iNamedProto "H".
-  iSplit; first done.
-  iIntros (Φ') "Hb Hcont". iApply wp_wrap_call; first done. cbn [snd].
-  rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre.
-  iIntros "%σ Hσ". cbn -[wrap_prog].
-  SI_at_boundary. SI_GC_agree.
-  iAssert (⌜∀ k lv, roots_m !! k = Some lv →
-            ∃ w, mem !! k = Some (Storing w) ∧ repr_lval (θC ρc) lv w⌝)%I as "%Hroots".
-  1: { iIntros (kk vv Hroots).
-       iPoseProof (big_sepM_lookup with "GCrootspto") as "(%wr & Hwr & %Hw2)"; first done.
-       iExists wr. iSplit; last done. iApply (gen_heap_valid with "HσC Hwr"). }
-  destruct (make_repr (θC ρc) roots_m mem) as [privmem Hpriv]; try done.
-
-  assert (GC_correct (ζC ρc) (θC ρc)) as HGC'.
-  { eapply GC_correct_transport_rev; last done; done. }
-
-  iApply wp_pre_cases_c_prim; [done..|].
-  iExists (λ '(e', σ'), ∃ γ χC' ζC' θC' (aret:loc) mem',
-      χC ρc !! γ = None ∧
-      χC' = <[ γ := LlocPrivate ]> (χC ρc) ∧
-      ζC' = <[ γ := Bforeign None ]> (ζC ρc) ∧
-      GC_correct ζC' θC' ∧
-      repr θC' roots_m privmem mem' ∧
-      roots_are_live θC' roots_m ∧
-      θC' !! γ = Some aret ∧
-      e' = WrSE (ExprV (# aret)) ∧
-      σ' = CState (WrapstateC χC' ζC' θC' (rootsC ρc)) mem').
-  iSplit. { iPureIntro. econstructor; naive_solver. }
-  iIntros (? ? ? (γ & χC' & ζC' & θC' & aret & mem' &
-                  HγNone & -> & -> & HGCOK' & Hrepr' & Hrootslive' & ?)).
-  destruct_and!; simplify_eq.
-
-  iMod (hgh_alloc_block with "GCHGH") as "(GCHGH & Hpto & Hfresh)"; first eassumption.
-  iMod (set_to_none _ _ _ _ Hpriv with "HσC GCrootspto") as "(HσC&GCrootspto)".
-  iMod (set_to_some _ _ _ _ Hrepr' with "HσC GCrootspto") as "(HσC&GCrootspto)".
-  iMod (ghost_var_update_halves with "GCζ SIζ") as "(GCζ&SIζ)".
-  iMod (ghost_var_update_halves with "GCχ SIχ") as "(GCχ&SIχ)".
-  iMod (ghost_var_update_halves with "GCθ SIθ") as "(GCθ&SIθ)".
-
-  do 3 iModIntro. iFrame. cbn -[wrap_prog].
-  iSplitL "SIinit". { iExists false. iFrame. }
-  iApply wp_value; first done.
-  iApply "Hcont". iFrame.
-  iApply ("Cont" $! θC' γ with "[-]"); try done.
-  iFrame "Hpto". iSplit; last by eauto.
-  rewrite /GC /named.
-  iExists _, _, σMLvirt, _, _. iFrame; eauto.
-Qed.
-
+Admitted.
+(*   iIntros (? ? ? ?) "H". unfold mprogwp. iNamedProto "H". *)
+(*   iSplit; first done. *)
+(*   iIntros (Φ') "Hb Hcont". iApply wp_wrap_call; first done. cbn [snd]. *)
+(*   rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre. *)
+(*   iIntros "%σ Hσ". cbn -[wrap_prog]. *)
+(*   SI_at_boundary. SI_GC_agree. *)
+(*   iAssert (⌜∀ k lv, roots_m !! k = Some lv → *)
+(*             ∃ w, mem !! k = Some (Storing w) ∧ repr_lval (θC ρc) lv w⌝)%I as "%Hroots". *)
+(*   1: { iIntros (kk vv Hroots). *)
+(*        iPoseProof (big_sepM_lookup with "GCrootspto") as "(%wr & Hwr & %Hw2)"; first done. *)
+(*        iExists wr. iSplit; last done. iApply (gen_heap_valid with "HσC Hwr"). } *)
+(*   destruct (make_repr (θC ρc) roots_m mem) as [privmem Hpriv]; try done. *)
+(**)
+(*   assert (GC_correct (ζC ρc) (θC ρc)) as HGC'. *)
+(*   { eapply GC_correct_transport_rev; last done; done. } *)
+(**)
+(*   iApply wp_pre_cases_c_prim; [done..|]. *)
+(*   iExists (λ '(e', σ'), ∃ γ χC' ζC' θC' (aret:loc) mem', *)
+(*       χC ρc !! γ = None ∧ *)
+(*       χC' = <[ γ := LlocPrivate ]> (χC ρc) ∧ *)
+(*       ζC' = <[ γ := Bforeign None ]> (ζC ρc) ∧ *)
+(*       GC_correct ζC' θC' ∧ *)
+(*       repr θC' roots_m privmem mem' ∧ *)
+(*       roots_are_live θC' roots_m ∧ *)
+(*       θC' !! γ = Some aret ∧ *)
+(*       e' = WrSE (ExprV (# aret)) ∧ *)
+(*       σ' = CState (WrapstateC χC' ζC' θC' (rootsC ρc)) mem'). *)
+(*   iSplit. { iPureIntro. econstructor; naive_solver. } *)
+(*   iIntros (? ? ? (γ & χC' & ζC' & θC' & aret & mem' & *)
+(*                   HγNone & -> & -> & HGCOK' & Hrepr' & Hrootslive' & ?)). *)
+(*   destruct_and!; simplify_eq. *)
+(**)
+(*   iMod (hgh_alloc_block with "GCHGH") as "(GCHGH & Hpto & Hfresh)"; first eassumption. *)
+(*   iMod (set_to_none _ _ _ _ Hpriv with "HσC GCrootspto") as "(HσC&GCrootspto)". *)
+(*   iMod (set_to_some _ _ _ _ Hrepr' with "HσC GCrootspto") as "(HσC&GCrootspto)". *)
+(*   iMod (ghost_var_update_halves with "GCζ SIζ") as "(GCζ&SIζ)". *)
+(*   iMod (ghost_var_update_halves with "GCχ SIχ") as "(GCχ&SIχ)". *)
+(*   iMod (ghost_var_update_halves with "GCθ SIθ") as "(GCθ&SIθ)". *)
+(**)
+(*   do 3 iModIntro. iFrame. cbn -[wrap_prog]. *)
+(*   iSplitL "SIinit". { iExists false. iFrame. } *)
+(*   iApply wp_value; first done. *)
+(*   iApply "Hcont". iFrame. *)
+(*   iApply ("Cont" $! θC' γ with "[-]"); try done. *)
+(*   iFrame "Hpto". iSplit; last by eauto. *)
+(*   rewrite /GC /named. *)
+(*   iExists _, _, σMLvirt, _, _. iFrame; eauto. *)
+(* Qed. *)
+(**)
 End Laws.

--- a/theories/interop/wp_prims/read_foreign.v
+++ b/theories/interop/wp_prims/read_foreign.v
@@ -28,7 +28,7 @@ Proof using.
   rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre.
   iIntros "%σ Hσ". cbn -[wrap_prog].
   SI_at_boundary. iNamed "HGC". SI_GC_agree.
-  iAssert ⌜∃ m', ζC ρc !! γ = Some (Bforeign m' (Some w'))⌝%I as "%Helem2".
+  iAssert ⌜∃ m', ζC ρc !! γ = Some (Bforeign (m', Some w'))⌝%I as "%Helem2".
   {
     iDestruct "Hpto" as "[Hpto _]".
     iDestruct (hgh_lookup_foreign with "GCHGH Hpto") as %(?&_&?). iPureIntro. eauto.

--- a/theories/interop/wp_prims/read_foreign.v
+++ b/theories/interop/wp_prims/read_foreign.v
@@ -32,8 +32,9 @@ Proof using.
   {
     iDestruct (hgh_lookup_block with "GCHGH Hpto") as %(b&Hb&Hγ).
     inversion Hb; subst; eauto.
+    iPureIntro. (* contradiction with Hγ *)
+    admit.
   }
-
   iApply wp_pre_cases_c_prim; [done..|].
   iExists (λ '(e', σ'), e' = WrSE (ExprV w') ∧ σ' = CState ρc mem).
   iSplit. { iPureIntro; econstructor; eauto. }
@@ -44,6 +45,6 @@ Proof using.
   iApply ("Cont" with "[- $Hpto]").
   rewrite /GC /named. iExists _, _, σMLvirt, _, _.
   iFrame. iPureIntro; split_and!; eauto.
-Qed.
+Admitted.
 
 End Laws.

--- a/theories/interop/wp_prims/read_foreign.v
+++ b/theories/interop/wp_prims/read_foreign.v
@@ -30,6 +30,7 @@ Proof using.
   SI_at_boundary. iNamed "HGC". SI_GC_agree.
   iAssert ⌜∃ m', ζC ρc !! γ = Some (Bforeign m' (Some w'))⌝%I as "%Helem2".
   {
+    iDestruct "Hpto" as "[Hpto _]".
     iDestruct (hgh_lookup_foreign with "GCHGH Hpto") as %(?&_&?). iPureIntro. eauto.
   }
   destruct Helem2 as [m' Helem2].

--- a/theories/interop/wp_prims/read_foreign.v
+++ b/theories/interop/wp_prims/read_foreign.v
@@ -22,27 +22,28 @@ Import mlanguage.
 
 Lemma read_foreign_correct e : |- wrap_prog e :: read_foreign_proto.
 Proof using.
-  iIntros (? ? ? ?) "H". unfold mprogwp. iNamedProto "H".
-  iSplit; first done.
-  iIntros (Φ') "Hb Hcont". iApply wp_wrap_call; first done. cbn [snd].
-  rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre.
-  iIntros "%σ Hσ". cbn -[wrap_prog].
-  SI_at_boundary. iNamed "HGC". SI_GC_agree.
-  iAssert ⌜ζC ρc !! γ = Some (Bforeign (Some w'))⌝%I as "%Helem2".
-  { iDestruct "Hpto" as "(Hpto & _)".
-    iDestruct (hgh_lookup_block with "GCHGH Hpto") as %(b&Hb&Hγ).
-    inversion Hb; subst; eauto. }
-
-  iApply wp_pre_cases_c_prim; [done..|].
-  iExists (λ '(e', σ'), e' = WrSE (ExprV w') ∧ σ' = CState ρc mem).
-  iSplit. { iPureIntro; econstructor; eauto. }
-  iIntros (? ? ? (? & ?)); simplify_eq.
-  do 3 iModIntro. iFrame. iSplitL "SIinit". { iExists false. iFrame. }
-  iApply wp_value; first done.
-  iApply "Hcont". iFrame.
-  iApply ("Cont" with "[- $Hpto]").
-  rewrite /GC /named. iExists _, _, σMLvirt, _, _.
-  iFrame. iPureIntro; split_and!; eauto.
-Qed.
-
+Admitted.
+(*   iIntros (? ? ? ?) "H". unfold mprogwp. iNamedProto "H". *)
+(*   iSplit; first done. *)
+(*   iIntros (Φ') "Hb Hcont". iApply wp_wrap_call; first done. cbn [snd]. *)
+(*   rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre. *)
+(*   iIntros "%σ Hσ". cbn -[wrap_prog]. *)
+(*   SI_at_boundary. iNamed "HGC". SI_GC_agree. *)
+(*   iAssert ⌜ζC ρc !! γ = Some (Bforeign (Some w'))⌝%I as "%Helem2". *)
+(*   { iDestruct "Hpto" as "(Hpto & _)". *)
+(*     iDestruct (hgh_lookup_block with "GCHGH Hpto") as %(b&Hb&Hγ). *)
+(*     inversion Hb; subst; eauto. } *)
+(**)
+(*   iApply wp_pre_cases_c_prim; [done..|]. *)
+(*   iExists (λ '(e', σ'), e' = WrSE (ExprV w') ∧ σ' = CState ρc mem). *)
+(*   iSplit. { iPureIntro; econstructor; eauto. } *)
+(*   iIntros (? ? ? (? & ?)); simplify_eq. *)
+(*   do 3 iModIntro. iFrame. iSplitL "SIinit". { iExists false. iFrame. } *)
+(*   iApply wp_value; first done. *)
+(*   iApply "Hcont". iFrame. *)
+(*   iApply ("Cont" with "[- $Hpto]"). *)
+(*   rewrite /GC /named. iExists _, _, σMLvirt, _, _. *)
+(*   iFrame. iPureIntro; split_and!; eauto. *)
+(* Qed. *)
+(**)
 End Laws.

--- a/theories/interop/wp_prims/read_foreign.v
+++ b/theories/interop/wp_prims/read_foreign.v
@@ -22,28 +22,28 @@ Import mlanguage.
 
 Lemma read_foreign_correct e : |- wrap_prog e :: read_foreign_proto.
 Proof using.
-Admitted.
-(*   iIntros (? ? ? ?) "H". unfold mprogwp. iNamedProto "H". *)
-(*   iSplit; first done. *)
-(*   iIntros (Φ') "Hb Hcont". iApply wp_wrap_call; first done. cbn [snd]. *)
-(*   rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre. *)
-(*   iIntros "%σ Hσ". cbn -[wrap_prog]. *)
-(*   SI_at_boundary. iNamed "HGC". SI_GC_agree. *)
-(*   iAssert ⌜ζC ρc !! γ = Some (Bforeign (Some w'))⌝%I as "%Helem2". *)
-(*   { iDestruct "Hpto" as "(Hpto & _)". *)
-(*     iDestruct (hgh_lookup_block with "GCHGH Hpto") as %(b&Hb&Hγ). *)
-(*     inversion Hb; subst; eauto. } *)
-(**)
-(*   iApply wp_pre_cases_c_prim; [done..|]. *)
-(*   iExists (λ '(e', σ'), e' = WrSE (ExprV w') ∧ σ' = CState ρc mem). *)
-(*   iSplit. { iPureIntro; econstructor; eauto. } *)
-(*   iIntros (? ? ? (? & ?)); simplify_eq. *)
-(*   do 3 iModIntro. iFrame. iSplitL "SIinit". { iExists false. iFrame. } *)
-(*   iApply wp_value; first done. *)
-(*   iApply "Hcont". iFrame. *)
-(*   iApply ("Cont" with "[- $Hpto]"). *)
-(*   rewrite /GC /named. iExists _, _, σMLvirt, _, _. *)
-(*   iFrame. iPureIntro; split_and!; eauto. *)
-(* Qed. *)
-(**)
+  iIntros (? ? ? ?) "H". unfold mprogwp. iNamedProto "H".
+  iSplit; first done.
+  iIntros (Φ') "Hb Hcont". iApply wp_wrap_call; first done. cbn [snd].
+  rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre.
+  iIntros "%σ Hσ". cbn -[wrap_prog].
+  SI_at_boundary. iNamed "HGC". SI_GC_agree.
+  iAssert ⌜ζC ρc !! γ = Some (Bforeign m (Some w'))⌝%I as "%Helem2".
+  {
+    iDestruct (hgh_lookup_block with "GCHGH Hpto") as %(b&Hb&Hγ).
+    inversion Hb; subst; eauto.
+  }
+
+  iApply wp_pre_cases_c_prim; [done..|].
+  iExists (λ '(e', σ'), e' = WrSE (ExprV w') ∧ σ' = CState ρc mem).
+  iSplit. { iPureIntro; econstructor; eauto. }
+  iIntros (? ? ? (? & ?)); simplify_eq.
+  do 3 iModIntro. iFrame. iSplitL "SIinit". { iExists false. iFrame. }
+  iApply wp_value; first done.
+  iApply "Hcont". iFrame.
+  iApply ("Cont" with "[- $Hpto]").
+  rewrite /GC /named. iExists _, _, σMLvirt, _, _.
+  iFrame. iPureIntro; split_and!; eauto.
+Qed.
+
 End Laws.

--- a/theories/interop/wp_prims/read_foreign.v
+++ b/theories/interop/wp_prims/read_foreign.v
@@ -4,7 +4,7 @@ From melocoton Require Import named_props stdpp_extra.
 From melocoton.mlanguage Require Import mlanguage.
 From melocoton.c_interface Require Import defs notation resources.
 From melocoton.interop Require Import state lang basics_resources.
-From melocoton.interop Require Export prims weakestpre prims_proto.
+From melocoton.interop Require Export prims weakestpre prims_proto update_laws.
 From melocoton.interop.wp_prims Require Import common.
 From melocoton.mlanguage Require Import weakestpre.
 Import Wrap.
@@ -28,13 +28,11 @@ Proof using.
   rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre.
   iIntros "%σ Hσ". cbn -[wrap_prog].
   SI_at_boundary. iNamed "HGC". SI_GC_agree.
-  iAssert ⌜ζC ρc !! γ = Some (Bforeign m (Some w'))⌝%I as "%Helem2".
+  iAssert ⌜∃ m', ζC ρc !! γ = Some (Bforeign m' (Some w'))⌝%I as "%Helem2".
   {
-    iDestruct (hgh_lookup_block with "GCHGH Hpto") as %(b&Hb&Hγ).
-    inversion Hb; subst; eauto.
-    iPureIntro. (* contradiction with Hγ *)
-    admit.
+    iDestruct (hgh_lookup_foreign with "GCHGH Hpto") as %(?&_&?). iPureIntro. eauto.
   }
+  destruct Helem2 as [m' Helem2].
   iApply wp_pre_cases_c_prim; [done..|].
   iExists (λ '(e', σ'), e' = WrSE (ExprV w') ∧ σ' = CState ρc mem).
   iSplit. { iPureIntro; econstructor; eauto. }
@@ -45,6 +43,6 @@ Proof using.
   iApply ("Cont" with "[- $Hpto]").
   rewrite /GC /named. iExists _, _, σMLvirt, _, _.
   iFrame. iPureIntro; split_and!; eauto.
-Admitted.
+Qed.
 
 End Laws.

--- a/theories/interop/wp_prims/write_foreign.v
+++ b/theories/interop/wp_prims/write_foreign.v
@@ -23,33 +23,31 @@ Import mlanguage.
 
 Lemma write_foreign_correct e : |- wrap_prog e :: write_foreign_proto.
 Proof using.
-Admitted.
-(*   iIntros (? ? ? ?) "H". unfold mprogwp. iNamedProto "H". *)
-(*   iSplit; first done. *)
-(*   iIntros (Φ') "Hb Hcont". iApply wp_wrap_call; first done. cbn [snd]. *)
-(*   rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre. *)
-(*   iIntros "%σ Hσ". cbn -[wrap_prog]. *)
-(*   SI_at_boundary. iNamed "HGC". SI_GC_agree. *)
-(*   iDestruct "Hpto" as "(Hpto & _)". *)
-(*   iPoseProof (hgh_lookup_block with "GCHGH Hpto") as (b) "(%Hb&%Hγ)". *)
-(*   inversion Hb; subst; clear Hb. *)
-(**)
-(*   iApply wp_pre_cases_c_prim; [done..|]. *)
-(*   iExists (λ '(e', σ'), *)
-(*     e' = WrSE (ExprV #0) ∧ *)
-(*     σ' = CState (WrapstateC (χC ρc) (<[γ:=Bforeign (Some w')]> (ζC ρc)) (θC ρc) (rootsC ρc)) mem). *)
-(*   iSplit. { iPureIntro; econstructor; eauto. } *)
-(*   iIntros (? ? ? (? & ?)); simplify_eq. *)
-(*   iMod (ghost_var_update_halves with "SIζ GCζ") as "(SIζ&GCζ)". *)
-(*   iMod (hgh_modify_block with "GCHGH Hpto") as "(GCHGH & Hpto)"; first done. *)
-(*   do 3 iModIntro. iFrame. cbn -[wrap_prog] in *. *)
-(*   iSplitL "SIinit". { iExists false. iFrame. } *)
-(*   iApply wp_value; first done. *)
-(*   change (Z.of_nat 0) with (Z0). *)
-(*   iApply "Hcont". iFrame. *)
-(*   iApply ("Cont" with "[- $Hpto]"); iSplit; last done. *)
-(*   rewrite /GC /named. iExists _, _, _, _, _. iFrame. iPureIntro; split_and!; eauto. *)
-(*   eapply GC_correct_modify_foreign; eauto. *)
-(* Qed. *)
-(**)
+  iIntros (? ? ? ?) "H". unfold mprogwp. iNamedProto "H".
+  iSplit; first done.
+  iIntros (Φ') "Hb Hcont". iApply wp_wrap_call; first done. cbn [snd].
+  rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre.
+  iIntros "%σ Hσ".
+  SI_at_boundary. iNamed "HGC". SI_GC_agree.
+  iPoseProof (hgh_lookup_block with "GCHGH Hpto") as (b) "(%Hb&%Hγ)".
+  inversion Hb; subst; clear Hb.
+
+  iApply wp_pre_cases_c_prim; [done..|].
+  iExists (λ '(e', σ'),
+    e' = WrSE (ExprV #0) ∧
+    σ' = CState (WrapstateC (χC ρc) (<[γ:=Bforeign Mut (Some w')]> (ζC ρc)) (θC ρc) (rootsC ρc)) mem).
+  iSplit. { iPureIntro; econstructor; eauto. }
+  iIntros (? ? ? (? & ?)); simplify_eq.
+  iMod (ghost_var_update_halves with "SIζ GCζ") as "(SIζ&GCζ)".
+  iMod (hgh_modify_block with "GCHGH Hpto") as "(GCHGH & Hpto)"; first done.
+  do 3 iModIntro. iFrame.
+  iSplitL "SIinit". { iExists false. iFrame. }
+  iApply wp_value; first done.
+  change (Z.of_nat 0) with (Z0).
+  iApply "Hcont". iFrame.
+  iApply ("Cont" with "[- $Hpto]").
+  rewrite /GC /named. iExists _, _, _, _, _. iFrame. iPureIntro; split_and!; eauto.
+  eapply GC_correct_modify_foreign; eauto.
+Qed.
+
 End Laws.

--- a/theories/interop/wp_prims/write_foreign.v
+++ b/theories/interop/wp_prims/write_foreign.v
@@ -23,32 +23,33 @@ Import mlanguage.
 
 Lemma write_foreign_correct e : |- wrap_prog e :: write_foreign_proto.
 Proof using.
-  iIntros (? ? ? ?) "H". unfold mprogwp. iNamedProto "H".
-  iSplit; first done.
-  iIntros (Φ') "Hb Hcont". iApply wp_wrap_call; first done. cbn [snd].
-  rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre.
-  iIntros "%σ Hσ". cbn -[wrap_prog].
-  SI_at_boundary. iNamed "HGC". SI_GC_agree.
-  iDestruct "Hpto" as "(Hpto & _)".
-  iPoseProof (hgh_lookup_block with "GCHGH Hpto") as (b) "(%Hb&%Hγ)".
-  inversion Hb; subst; clear Hb.
-
-  iApply wp_pre_cases_c_prim; [done..|].
-  iExists (λ '(e', σ'),
-    e' = WrSE (ExprV #0) ∧
-    σ' = CState (WrapstateC (χC ρc) (<[γ:=Bforeign (Some w')]> (ζC ρc)) (θC ρc) (rootsC ρc)) mem).
-  iSplit. { iPureIntro; econstructor; eauto. }
-  iIntros (? ? ? (? & ?)); simplify_eq.
-  iMod (ghost_var_update_halves with "SIζ GCζ") as "(SIζ&GCζ)".
-  iMod (hgh_modify_block with "GCHGH Hpto") as "(GCHGH & Hpto)"; first done.
-  do 3 iModIntro. iFrame. cbn -[wrap_prog] in *.
-  iSplitL "SIinit". { iExists false. iFrame. }
-  iApply wp_value; first done.
-  change (Z.of_nat 0) with (Z0).
-  iApply "Hcont". iFrame.
-  iApply ("Cont" with "[- $Hpto]"); iSplit; last done.
-  rewrite /GC /named. iExists _, _, _, _, _. iFrame. iPureIntro; split_and!; eauto.
-  eapply GC_correct_modify_foreign; eauto.
-Qed.
-
+Admitted.
+(*   iIntros (? ? ? ?) "H". unfold mprogwp. iNamedProto "H". *)
+(*   iSplit; first done. *)
+(*   iIntros (Φ') "Hb Hcont". iApply wp_wrap_call; first done. cbn [snd]. *)
+(*   rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre. *)
+(*   iIntros "%σ Hσ". cbn -[wrap_prog]. *)
+(*   SI_at_boundary. iNamed "HGC". SI_GC_agree. *)
+(*   iDestruct "Hpto" as "(Hpto & _)". *)
+(*   iPoseProof (hgh_lookup_block with "GCHGH Hpto") as (b) "(%Hb&%Hγ)". *)
+(*   inversion Hb; subst; clear Hb. *)
+(**)
+(*   iApply wp_pre_cases_c_prim; [done..|]. *)
+(*   iExists (λ '(e', σ'), *)
+(*     e' = WrSE (ExprV #0) ∧ *)
+(*     σ' = CState (WrapstateC (χC ρc) (<[γ:=Bforeign (Some w')]> (ζC ρc)) (θC ρc) (rootsC ρc)) mem). *)
+(*   iSplit. { iPureIntro; econstructor; eauto. } *)
+(*   iIntros (? ? ? (? & ?)); simplify_eq. *)
+(*   iMod (ghost_var_update_halves with "SIζ GCζ") as "(SIζ&GCζ)". *)
+(*   iMod (hgh_modify_block with "GCHGH Hpto") as "(GCHGH & Hpto)"; first done. *)
+(*   do 3 iModIntro. iFrame. cbn -[wrap_prog] in *. *)
+(*   iSplitL "SIinit". { iExists false. iFrame. } *)
+(*   iApply wp_value; first done. *)
+(*   change (Z.of_nat 0) with (Z0). *)
+(*   iApply "Hcont". iFrame. *)
+(*   iApply ("Cont" with "[- $Hpto]"); iSplit; last done. *)
+(*   rewrite /GC /named. iExists _, _, _, _, _. iFrame. iPureIntro; split_and!; eauto. *)
+(*   eapply GC_correct_modify_foreign; eauto. *)
+(* Qed. *)
+(**)
 End Laws.

--- a/theories/interop/wp_prims/write_foreign.v
+++ b/theories/interop/wp_prims/write_foreign.v
@@ -36,7 +36,7 @@ Proof using.
   iApply wp_pre_cases_c_prim; [done..|].
   iExists (λ '(e', σ'),
     e' = WrSE (ExprV #0) ∧
-    σ' = CState (WrapstateC (χC ρc) (<[γ:=Bforeign Mut (Some w')]> (ζC ρc)) (θC ρc) (rootsC ρc)) mem).
+    σ' = CState (WrapstateC (χC ρc) (<[γ:=Bforeign (Mut, Some w')]> (ζC ρc)) (θC ρc) (rootsC ρc)) mem).
   iSplit. { iPureIntro; econstructor; eauto. }
   iIntros (? ? ? (? & ?)); simplify_eq.
   iMod (ghost_var_update_halves with "SIζ GCζ") as "(SIζ&GCζ)".

--- a/theories/interop/wp_prims/write_foreign.v
+++ b/theories/interop/wp_prims/write_foreign.v
@@ -29,6 +29,7 @@ Proof using.
   rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre.
   iIntros "%σ Hσ".
   SI_at_boundary. iNamed "HGC". SI_GC_agree.
+  iDestruct "Hpto" as "[Hpto Hγ]".
   iPoseProof (hgh_lookup_block with "GCHGH Hpto") as (b) "(%Hb&%Hγ)".
   inversion Hb; subst; clear Hb.
 
@@ -45,8 +46,9 @@ Proof using.
   iApply wp_value; first done.
   change (Z.of_nat 0) with (Z0).
   iApply "Hcont". iFrame.
-  iApply ("Cont" with "[- $Hpto]").
-  rewrite /GC /named. iExists _, _, _, _, _. iFrame. iPureIntro; split_and!; eauto.
+  iApply ("Cont" with "[- $Hpto]"). iFrame.
+  rewrite /GC /named. 
+  iExists _, _, _, _, _. iFrame. iPureIntro; split_and!; eauto.
   eapply GC_correct_modify_foreign; eauto.
 Qed.
 

--- a/theories/ml_lang/logrel/logrel.v
+++ b/theories/ml_lang/logrel/logrel.v
@@ -33,7 +33,7 @@ Notation na_tok := (na_own logrel_nais ⊤).
 
 Section logrel.
   Context `{SI: indexT}.
-  Context {Σ : gFunctors}. 
+  Context {Σ : gFunctors}.
   Context `{!heapG_ML Σ, !invG Σ, !logrelG Σ}.
   Notation D := (persistent_predO val (iPropI Σ)).
   Implicit Types τi : D.
@@ -57,6 +57,8 @@ Section logrel.
   Definition interp_unit : listO D -n> D := λne Δ, PersPred (λ w, ⌜w = #LitUnit⌝)%I.
   Definition interp_nat : listO D -n> D :=
     λne Δ, PersPred (λ w, ⌜∃ (n:Z), w = # n⌝)%I.
+  Definition interp_boxednat : listO D -n> D :=
+    λne Δ, PersPred (λ w, ⌜∃ (n:Z), w = # (LitBoxedInt n)⌝)%I.
   Definition interp_bool : listO D -n> D :=
     λne Δ, PersPred (λ w, ⌜∃ (b:bool), w = # b⌝)%I.
 
@@ -109,7 +111,7 @@ Section logrel.
     intros interp n Δ1 Δ2 HΔ; apply fixpoint_ne => τi w. solve_proper.
   Qed.
 
-  Program Definition interp_array_inv_L γ (l : loc) : iPropO Σ := 
+  Program Definition interp_array_inv_L γ (l : loc) : iPropO Σ :=
     (∃ vs, l ↦∗ vs ∗ ghost_var γ (1/2) vs)%I.
   Program Definition interp_array_inv_R γ : D -n> iPropO Σ := λne τi,
     (∃ vs, ([∗ list] v∈vs, τi v) ∗ ghost_var γ (1/2) vs)%I.
@@ -126,6 +128,7 @@ Section logrel.
     match τ return _ with
     | TUnit => interp_unit
     | TNat => interp_nat
+    | TBoxedNat => interp_boxednat
     | TBool => interp_bool
     | TProd τ1 τ2 => interp_prod (interp τ1) (interp τ2)
     | TSum τ1 τ2 => interp_sum (interp τ1) (interp τ2)

--- a/theories/ml_lang/pretty.v
+++ b/theories/ml_lang/pretty.v
@@ -12,6 +12,7 @@ Global Instance pretty_loc : Pretty loc :=
 Global Instance pretty_base_lit : Pretty base_lit :=
   λ l, match l with
        | LitInt z => pretty z
+       | LitBoxedInt z => pretty z +:+ "l"
        | LitBool b => if b then "true" else "false"
        | LitUnit => "()"
        | LitLoc l => "(loc " +:+ pretty l +:+ ")"


### PR DESCRIPTION
This PR add support for boxed integers, such as Int32, Int64 and NativeInt. 
This changes required modifying foreign block to specify whether the value they represent is immutable or not. 
Some proof about freezing which were previously specific about freezing value blocks have been generalized in the process. 
A new example showcase the usage of these boxed integers inside a simple proof.