### PR TITLE
Add notations for Oval in WP

### DIFF
--- a/theories/c_interop/rules.v
+++ b/theories/c_interop/rules.v
@@ -26,7 +26,7 @@ Lemma store_to_root pe (l:loc) (v v' : lval) w θ :
   repr_lval θ v w →
   {{{ GC θ ∗ l ↦roots v' }}}
      (#l <- w)%CE at pe
-  {{{ RET LitV LitUnit; GC θ ∗ l ↦roots v }}}%CE.
+  {{{ RETV LitV LitUnit; GC θ ∗ l ↦roots v }}}%CE.
 Proof.
   iIntros (Hrepr Φ) "(HGC&Hroot) HΦ".
   iDestruct (update_root with "[$HGC $Hroot]") as (w') "(Hpto & _ & Hupd)".
@@ -39,7 +39,7 @@ Qed.
 Lemma load_from_root pe (l:loc) (v : lval) dq θ :
   {{{ GC θ ∗ l ↦roots{dq} v }}}
      ( * #l)%CE at pe
-  {{{ w, RET w; l ↦roots{dq} v ∗ GC θ ∗ ⌜repr_lval θ v w⌝ }}}%CE.
+  {{{ w, RETV w; l ↦roots{dq} v ∗ GC θ ∗ ⌜repr_lval θ v w⌝ }}}%CE.
 Proof.
   iIntros (Φ) "(HGC&Hroot) HΦ".
   iDestruct (access_root with "[$HGC $Hroot]") as (w') "(Hpto & %Hrepr & Hupd)".
@@ -54,7 +54,7 @@ Lemma wp_int2val p Ψ θ (x : Z) :
   int2val_proto ⊑ Ψ →
   {{{ GC θ }}}
     (call: &"int2val" with (Val #x))%CE at ⟨p, Ψ⟩
-  {{{ w, RET w; GC θ ∗ ⌜repr_lval θ (Lint x) w⌝ }}}.
+  {{{ w, RETV w; GC θ ∗ ⌜repr_lval θ (Lint x) w⌝ }}}.
 Proof.
   iIntros (Hp Hproto Φ) "HGC Cont".
   wp_pures. wp_extern; first done.
@@ -70,7 +70,7 @@ Lemma wp_val2int p Ψ θ (w:word) (x : Z) :
   repr_lval θ (Lint x) w →
   {{{ GC θ }}}
     (call: &"val2int" with (Val w))%CE at ⟨p, Ψ⟩
-  {{{ RET #x; GC θ }}}.
+  {{{ RETV #x; GC θ }}}.
 Proof.
   iIntros (Hp Hproto Hrepr Φ) "HGC Cont".
   wp_pures. wp_extern; first done.
@@ -87,7 +87,7 @@ Lemma wp_registerroot p Ψ θ v w a :
   repr_lval θ v w →
   {{{ GC θ ∗ a ↦C w }}}
     (call: &"registerroot" with (Val (# a)))%CE at ⟨p, Ψ⟩
-  {{{ RET # 0; GC θ ∗ a ↦roots v }}}.
+  {{{ RETV # 0; GC θ ∗ a ↦roots v }}}.
 Proof.
   iIntros (Hp Hproto Hrepr Φ) "(HGC & Hpto) Cont".
   wp_pures. wp_extern; first done.
@@ -103,7 +103,7 @@ Lemma wp_unregisterroot p Ψ θ v a :
   unregisterroot_proto ⊑ Ψ →
   {{{ GC θ ∗ a ↦roots v }}}
     (call: &"unregisterroot" with (Val (# a)))%CE at ⟨p, Ψ⟩
-  {{{ w, RET # 0; GC θ ∗ a ↦C w ∗ ⌜repr_lval θ v w⌝ }}}.
+  {{{ w, RETV # 0; GC θ ∗ a ↦C w ∗ ⌜repr_lval θ v w⌝ }}}.
 Proof.
   iIntros (Hp Hproto Φ) "(HGC & Hpto) Cont".
   wp_pures. wp_extern; first done.
@@ -123,7 +123,7 @@ Lemma wp_modify p Ψ θ γ w mut tg vs v' w' i :
   (0 ≤ i < length vs)%Z →
   {{{ GC θ ∗ γ ↦vblk[mut] (tg, vs) }}}
     (call: &"modify" with (Val w, Val (# i), Val w'))%CE at ⟨p, Ψ⟩
-  {{{ RET #0; GC θ ∗ γ ↦vblk[mut] (tg, <[Z.to_nat i:=v']> vs) }}}.
+  {{{ RETV #0; GC θ ∗ γ ↦vblk[mut] (tg, <[Z.to_nat i:=v']> vs) }}}.
 Proof.
   intros Hp Hproto **. iIntros "(HGC & Hpto) Cont".
   wp_pures. wp_extern; first done.
@@ -141,7 +141,7 @@ Lemma wp_readfield p Ψ θ γ w m dq tg vs i :
   (0 ≤ i < length vs)%Z →
   {{{ GC θ ∗ γ ↦vblk[m]{dq} (tg, vs) }}}
     (call: &"readfield" with (Val w, Val (# i)))%CE at ⟨p, Ψ⟩
-  {{{ v' w', RET w';
+  {{{ v' w', RETV w';
         GC θ ∗ γ ↦vblk[m]{dq} (tg, vs) ∗
         ⌜vs !! (Z.to_nat i) = Some v'⌝ ∗
         ⌜repr_lval θ v' w'⌝ }}}.
@@ -161,7 +161,7 @@ Lemma wp_isblock p Ψ θ lv w :
   repr_lval θ lv w →
   {{{ GC θ }}}
     (call: &"isblock" with (Val w))%CE at ⟨p, Ψ⟩
-  {{{ RET #(match lv return Z with | Lloc _ => 1 | _ => 0 end); GC θ }}}.
+  {{{ RETV #(match lv return Z with | Lloc _ => 1 | _ => 0 end); GC θ }}}.
 Proof.
   intros Hp Hproto **. iIntros "HGC Cont".
   wp_pures. wp_extern; first done.
@@ -178,7 +178,7 @@ Lemma wp_isblock_true p Ψ θ γ w :
   repr_lval θ (Lloc γ) w →
   {{{ GC θ }}}
     (call: &"isblock" with (Val w))%CE at ⟨p, Ψ⟩
-  {{{ RET #1; GC θ }}}.
+  {{{ RETV #1; GC θ }}}.
 Proof.
   intros Hp Hproto **. iIntros "HGC Cont".
   iApply (wp_isblock with "HGC"); [done..|].
@@ -191,7 +191,7 @@ Lemma wp_isblock_false p Ψ θ z w :
   repr_lval θ (Lint z) w →
   {{{ GC θ }}}
     (call: &"isblock" with (Val w))%CE at ⟨p, Ψ⟩
-  {{{ RET #0; GC θ }}}.
+  {{{ RETV #0; GC θ }}}.
 Proof.
   intros Hp Hproto **. iIntros "HGC Cont".
   iApply (wp_isblock with "HGC"); [done..|].
@@ -204,7 +204,7 @@ Lemma wp_read_tag p Ψ θ γ w dq bl :
   repr_lval θ (Lloc γ) w →
   {{{ GC θ ∗ lstore_own_elem γ dq bl}}}
     (call: &"read_tag" with (Val w))%CE at ⟨p, Ψ⟩
-  {{{ RET #(tag_as_int (block_tag bl)); GC θ ∗ lstore_own_elem γ dq bl }}}.
+  {{{ RETV #(tag_as_int (block_tag bl)); GC θ ∗ lstore_own_elem γ dq bl }}}.
 Proof.
   intros Hp Hproto **. iIntros "(HGC&Hpto) Cont".
   wp_pures. wp_extern; first done.
@@ -221,7 +221,7 @@ Lemma wp_length p Ψ θ γ w m dq tg vs :
   repr_lval θ (Lloc γ) w →
   {{{ GC θ ∗ γ ↦vblk[m]{dq} (tg, vs) }}}
     (call: &"length" with (Val w))%CE at ⟨p, Ψ⟩
-  {{{ RET #(length vs);
+  {{{ RETV #(length vs);
         GC θ ∗ γ ↦vblk[m]{dq} (tg, vs) }}}.
 Proof.
   intros Hp Hproto **. iIntros "(HGC & Hpto) Cont".
@@ -241,7 +241,7 @@ Lemma wp_alloc tg p Ψ θ tgnum sz :
   vblock_tag_as_int tg = tgnum →
   {{{ GC θ }}}
     (call: &"alloc" with (Val (# tgnum), Val (# sz)))%CE at ⟨p, Ψ⟩
-  {{{ θ' γ w, RET w;
+  {{{ θ' γ w, RETV w;
         GC θ' ∗ γ ↦fresh (tg, List.repeat (Lint 0) (Z.to_nat sz)) ∗
         ⌜repr_lval θ' (Lloc γ) w⌝ }}}.
 Proof.
@@ -259,7 +259,7 @@ Lemma wp_alloc_foreign p Ψ θ :
   alloc_foreign_proto ⊑ Ψ →
   {{{ GC θ }}}
     (call: &"alloc_foreign" with ( ))%CE at ⟨p, Ψ⟩
-  {{{ θ' γ w, RET w;
+  {{{ θ' γ w, RETV w;
         GC θ' ∗ γ ↦foreignO[Mut] None ∗
         ⌜repr_lval θ' (Lloc γ) w⌝ }}}.
 Proof.
@@ -278,7 +278,7 @@ Lemma wp_write_foreign p Ψ θ w γ ao a' :
   repr_lval θ (Lloc γ) w →
   {{{ GC θ ∗ γ ↦foreignO[Mut] ao }}}
     (call: &"write_foreign" with (Val w, Val a'))%CE at ⟨p, Ψ⟩
-  {{{ RET (# 0); GC θ ∗ γ ↦foreign[Mut] a' }}}.
+  {{{ RETV (# 0); GC θ ∗ γ ↦foreign[Mut] a' }}}.
 Proof.
   intros Hp Hproto **. iIntros "(HGC & ?) Cont".
   wp_pures. wp_extern; first done.
@@ -295,7 +295,7 @@ Lemma wp_read_foreign p Ψ θ w γ a m dq :
   repr_lval θ (Lloc γ) w →
   {{{ GC θ ∗ γ ↦foreign[m]{dq} a }}}
     (call: &"read_foreign" with (Val w))%CE at ⟨p, Ψ⟩
-  {{{ RET a; GC θ ∗ γ ↦foreign[m]{dq} a }}}.
+  {{{ RETV a; GC θ ∗ γ ↦foreign[m]{dq} a }}}.
 Proof.
   intros Hp Hproto **. iIntros "(HGC & ?) Cont".
   wp_pures. wp_extern; first done.
@@ -317,7 +317,7 @@ Lemma wp_callback p ΨML Ψ θ w γ f x e lv' w' v' Φ :
       (▷ WP (App (ML_lang.Val (RecV f x e)) (ML_lang.Val v')) at ⟨∅, ΨML⟩ {{ Φ }})
   }}}
     (call: &"callback" with (Val w, Val w'))%CE at ⟨p, Ψ⟩
-  {{{ θ' vret lvret wret, RET wret;
+  {{{ θ' vret lvret wret, RETV wret;
         GC θ' ∗
         Φ (OVal vret) ∗
         lvret ~~ vret ∗
@@ -337,7 +337,7 @@ Lemma wp_main p Ψ Φ P :
   main_proto Φ P ⊑ Ψ →
   {{{ at_init ∗ P }}}
     (call: &"main" with ( ))%CE at ⟨p, Ψ⟩
-  {{{ x, RET code_int x; ⌜Φ x⌝ }}}.
+  {{{ x, RETV code_int x; ⌜Φ x⌝ }}}.
 Proof.
   intros Hp Hproto **. iIntros "(Hinit&HP) Cont".
   wp_pures. wp_extern; first done.
@@ -376,7 +376,7 @@ Lemma wp_CAMLunregister1 (l:loc) lv p θ Ψ :
   unregisterroot_proto ⊑ Ψ →
   {{{ GC θ ∗ l ↦roots lv}}}
     (CAMLunregister1 (#l))%CE at ⟨p, Ψ⟩
-  {{{ RET #0; GC θ }}}.
+  {{{ RETV #0; GC θ }}}.
 Proof.
   iIntros (???) "Hin Cont".
   unfold CAMLunregister1.

--- a/theories/c_lang/derived_laws.v
+++ b/theories/c_lang/derived_laws.v
@@ -30,7 +30,7 @@ Implicit Types sz off : nat.
 Lemma wp_Malloc s n :
   (0 < n)%Z →
   {{{ True }}} Malloc (Val $ LitV $ LitInt $ n) at s
-  {{{ l, RET LitV (LitLoc l); l I↦C∗ replicate (Z.to_nat n) None }}}.
+  {{{ l, RETV LitV (LitLoc l); l I↦C∗ replicate (Z.to_nat n) None }}}.
 Proof.
   iIntros (Hzs Φ) "_ HΦ". iApply wp_Malloc_seq; [done..|]. iModIntro.
   iIntros (l) "Hlm". iApply "HΦ".
@@ -41,7 +41,7 @@ Lemma wp_Malloc_vec s n :
   (0 < n)%Z →
   {{{ True }}}
     Malloc #n at s
-  {{{ l, RET #l; l I↦C∗ vreplicate (Z.to_nat n) None }}}.
+  {{{ l, RETV #l; l I↦C∗ vreplicate (Z.to_nat n) None }}}.
 Proof.
   iIntros (Hzs Φ) "_ HΦ". iApply wp_Malloc; [ lia | done | .. ]. iModIntro.
   iIntros (l) "Hl". iApply "HΦ". rewrite vec_to_list_replicate. iFrame.
@@ -50,7 +50,7 @@ Qed.
 (** Accessing array elements *)
 Lemma wp_load_offset s l dq off vs (v:val) :
   vs !! off = Some (Some v) →
-  {{{ ▷ l I↦C∗{dq} vs }}} * #(l +ₗ off) at s {{{ RET v; l I↦C∗{dq} vs }}}%CE.
+  {{{ ▷ l I↦C∗{dq} vs }}} * #(l +ₗ off) at s {{{ RETV v; l I↦C∗{dq} vs }}}%CE.
 Proof.
   iIntros (Hlookup Φ) ">Hl HΦ".
   iDestruct (update_array l _ _ _ _ Hlookup with "Hl") as "[Hl1 Hl2]".
@@ -61,7 +61,7 @@ Qed.
 
 Lemma wp_store_offset s l off vs (v:val) :
   off < length vs →
-  {{{ ▷ l I↦C∗ vs }}} #(l +ₗ off) <- v at s {{{ RET #0; l I↦C∗ <[off:=Some v]> vs }}}%CE.
+  {{{ ▷ l I↦C∗ vs }}} #(l +ₗ off) <- v at s {{{ RETV #0; l I↦C∗ <[off:=Some v]> vs }}}%CE.
 Proof.
   iIntros (Hlength Φ) ">Hl HΦ".
   destruct (lookup_lt_is_Some_2 _ _ Hlength) as [vv Hlookup].
@@ -71,7 +71,7 @@ Proof.
 Qed.
 
 Lemma wp_store_offset_vec s l sz (off : fin sz) (vs : vec (option val) sz) (v:val) :
-  {{{ ▷ l I↦C∗ vs }}} #(l +ₗ off) <- v at s {{{ RET #0; l I↦C∗ vinsert off (Some v) vs }}}%CE.
+  {{{ ▷ l I↦C∗ vs }}} #(l +ₗ off) <- v at s {{{ RETV #0; l I↦C∗ vinsert off (Some v) vs }}}%CE.
 Proof.
   setoid_rewrite vec_to_list_insert. apply wp_store_offset.
   rewrite vec_to_list_length. apply fin_to_nat_lt.
@@ -79,7 +79,7 @@ Qed.
 
 (** Freeing a region *)
 Lemma wp_free_array s l vs :
-  {{{ ▷ l I↦C∗ vs }}} free (#l, #(Z.of_nat (length vs))) at s {{{ RET LitV LitUnit; True }}}%CE.
+  {{{ ▷ l I↦C∗ vs }}} free (#l, #(Z.of_nat (length vs))) at s {{{ RETV LitV LitUnit; True }}}%CE.
 Proof.
   iIntros (Φ) ">Hl HΦ".
   iApply (wp_step with "HΦ"). iApply wp_lift_atomic_head_step; first done.
@@ -115,7 +115,7 @@ Qed.
 
 Lemma wp_free_array' s l z vs :
   z = Z.of_nat (length vs) →
-  {{{ ▷ l I↦C∗ vs }}} free (#l, #z) at s {{{ RET LitV LitUnit; True }}}%CE.
+  {{{ ▷ l I↦C∗ vs }}} free (#l, #z) at s {{{ RETV LitV LitUnit; True }}}%CE.
 Proof. iIntros (-> Φ) "H HΦ". by iApply (wp_free_array with "H"). Qed.
 
 End lifting.

--- a/theories/c_lang/primitive_laws.v
+++ b/theories/c_lang/primitive_laws.v
@@ -70,7 +70,7 @@ Qed.
 Lemma wp_Malloc_seq n :
   (0 < n)%Z →
   {{{ True }}} Malloc (Val $ LitV $ LitInt $ n) at p
-  {{{ l, RET LitV (LitLoc l); [∗ list] i ∈ seq 0 (Z.to_nat n), (l +ₗ (i : nat)) ↦C ? }}}.
+  {{{ l, RETV LitV (LitLoc l); [∗ list] i ∈ seq 0 (Z.to_nat n), (l +ₗ (i : nat)) ↦C ? }}}.
 Proof.
   iIntros (Hn Φ) "_ HΦ". iApply wp_lift_atomic_head_step; first done.
   iIntros (σ1) "Hσ". iModIntro. iSplit; first (destruct n; eauto with lia head_step).
@@ -85,7 +85,7 @@ Qed.
 
 Lemma wp_free s l (v:option val) :
   {{{ ▷ l O↦C (Some v) }}} Free (Val $ LitV $ LitLoc l) (Val $ LitV $ LitInt 1) at s
-  {{{ RET LitV LitUnit; True }}}.
+  {{{ RETV LitV LitUnit; True }}}.
 Proof.
   iIntros (Φ) "> Hl HΦ". iApply (wp_step with "HΦ"). iApply wp_lift_atomic_head_step; first done.
   iIntros (σ1) "Hσ". iDestruct (gen_heap_valid with "Hσ Hl") as "%HH". iModIntro.
@@ -100,7 +100,7 @@ Proof.
 Qed.
 
 Lemma wp_load s l dq v :
-  {{{ ▷ l ↦C{dq} v }}} Load (Val $ LitV $ LitLoc l) at s {{{ RET v; l ↦C{dq} v }}}.
+  {{{ ▷ l ↦C{dq} v }}} Load (Val $ LitV $ LitLoc l) at s {{{ RETV v; l ↦C{dq} v }}}.
 Proof.
   iIntros (Φ) "> Hl HΦ". iApply (wp_step with "HΦ"). iApply wp_lift_atomic_head_step; first done.
   iIntros (σ1) "Hσ". iDestruct (gen_heap_valid with "Hσ Hl") as "%HH". iModIntro.
@@ -112,7 +112,7 @@ Qed.
 
 Lemma wp_store s l (v':option val) v :
   {{{ ▷ l O↦C Some v' }}} Store (Val $ LitV $ LitLoc l) (Val v) at s
-  {{{ RET LitV LitUnit; l ↦C v }}}.
+  {{{ RETV LitV LitUnit; l ↦C v }}}.
 Proof.
   iIntros (Φ) "> Hl HΦ". iApply (wp_step with "HΦ"). iApply wp_lift_atomic_head_step; first done.
   iIntros (σ1) "Hσ !>". iDestruct (gen_heap_valid with "Hσ Hl") as %?.

--- a/theories/examples/add.v
+++ b/theories/examples/add.v
@@ -30,7 +30,7 @@ Definition add_one_ml_spec : protocol ML_lang.val Σ :=
   !! (x:Z)
     {{ True }}
       "add_one" with [ (#ML x) ]
-    {{ RET (#ML(x + 1)); True }}.
+    {{ RETV (#ML(x + 1)); True }}.
 
 Definition add_one_code (x : expr) : expr :=
   let: "r" := Int_val(x) in

--- a/theories/examples/box.v
+++ b/theories/examples/box.v
@@ -89,7 +89,7 @@ Section Proofs.
     !! interp Δ v
     {{ "#Hv" ∷ interp Δ v ∗ "Hna" ∷ na_tok }}
       "box_create" with [v]
-    {{ vr, RET vr; na_tok ∗ box_interp Ψ interp Δ vr }}.
+    {{ vr, RETV vr; na_tok ∗ box_interp Ψ interp Δ vr }}.
 
   Definition box_update_spec_ML : protocol ML_lang.val Σ :=
     !! interp Δ vn vb
@@ -99,7 +99,7 @@ Section Proofs.
        "#Hbox" ∷ ▷ box_interp Ψ interp Δ vb
     }}
       "box_update" with [vn; vb]
-    {{ RET #(); na_tok }}.
+    {{ RETV #(); na_tok }}.
 
   Definition box_listen_spec_ML : protocol ML_lang.val Σ :=
     !! interp Δ vl vb
@@ -109,7 +109,7 @@ Section Proofs.
        "Hna" ∷ na_tok
     }}
       "box_listen" with [vl; vb]
-    {{ RET #(); na_tok }}.
+    {{ RETV #(); na_tok }}.
 
   Import melocoton.c_lang.primitive_laws melocoton.c_lang.proofmode.
 

--- a/theories/examples/compression/buffers_client.v
+++ b/theories/examples/compression/buffers_client.v
@@ -46,7 +46,7 @@ Section MLclient.
   Lemma ML_client_spec ℓ dq (zz : buffer) :
     {{{ ℓ ↦∗{dq} map (λ (x:Z), #x) zz }}}
       ML_client_code #ℓ at ML_client_env
-    {{{ RET #(if is_compressible zz then true else false); ℓ ↦∗{dq} map (λ (x:Z), #x) zz }}}.
+    {{{ RETV #(if is_compressible zz then true else false); ℓ ↦∗{dq} map (λ (x:Z), #x) zz }}}.
   Proof.
     iIntros (Φ) "Hℓ Cont".
     unfold ML_client_code, ML_client_env. wp_pures.

--- a/theories/examples/compression/buffers_proof_alloc.v
+++ b/theories/examples/compression/buffers_proof_alloc.v
@@ -23,7 +23,7 @@ Section Proofs.
     {{{ GC θ }}}
          call: &buffers_specs.buf_alloc_name with (wcap)
       at ⟨buf_lib_prog, prims_proto Ψ⟩
-    {{{ w' θ' lv ℓ, RET w';
+    {{{ w' θ' lv ℓ, RETV w';
        GC θ' ∗ isBufferRecord lv ℓ (buf_alloc_res_buffer n) n ∗
        ⌜repr_lval θ' lv w'⌝ }}}%CE.
   Proof.

--- a/theories/examples/even_odd.v
+++ b/theories/examples/even_odd.v
@@ -30,13 +30,13 @@ Definition is_odd_proto : protocol val Σ :=
   !! (x:Z)
   {{ "%" ∷ ⌜(0 ≤ x)%Z⌝ }}
     "is_odd" with [ #x ]
-  {{ RET #(Z.odd x); True }}.
+  {{ RETV #(Z.odd x); True }}.
 
 Definition is_even_proto : protocol val Σ :=
   !! (x:Z)
   {{ "%" ∷ ⌜(0 ≤ x)%Z⌝ }}
     "is_even" with [ #x ]
-  {{ RET #(Z.even x); True }}.
+  {{ RETV #(Z.even x); True }}.
 
 Lemma wp_is_even (x:Z) :
   (0 ≤ x)%Z →
@@ -122,7 +122,7 @@ Lemma is_even_linked_spec (x:Z) :
   (0 ≤ x)%Z →
   {{{ link_in_state _ _ Boundary }}}
     LkSE (Link.ExprCall "is_even" [ #x ]) at ⟪fullprog, ⊥⟫
-  {{{ RET #(Z.even x); link_in_state _ _ Boundary }}}.
+  {{{ RETV #(Z.even x); link_in_state _ _ Boundary }}}.
 Proof.
   iIntros (Hx Φ) "Hlkst HΦ".
   iApply (wp_internal_call_at_boundary fullprog with "[$Hlkst]").
@@ -135,7 +135,7 @@ Lemma is_odd_linked_spec (x:Z) :
   (0 ≤ x)%Z →
   {{{ link_in_state _ _ Boundary }}}
     LkSE (Link.ExprCall "is_odd" [ #x ]) at ⟪fullprog, ⊥⟫
-  {{{ RET #(Z.odd x); link_in_state _ _ Boundary }}}.
+  {{{ RETV #(Z.odd x); link_in_state _ _ Boundary }}}.
 Proof.
   iIntros (Hx Φ) "Hlkst HΦ".
   iApply (wp_internal_call_at_boundary fullprog with "[$Hlkst]").

--- a/theories/examples/gmtime.v
+++ b/theories/examples/gmtime.v
@@ -30,7 +30,7 @@ Section C_spec.
     {{ True }}
       "gmtime" with ([ #C w ])
     {{
-      (a : loc) (tm_sec : Z) (tm_min : Z), RET(#C a);
+      (a : loc) (tm_sec : Z) (tm_min : Z), RETV (#C a);
       a ↦C∗ [ #C tm_sec; #C tm_min ]
     }}.
 
@@ -65,7 +65,7 @@ Section FFI_spec.
       {{ True }}
         "caml_gmtime" with [(#ML (ML_lang.LitBoxedInt t))]
       {{
-        (tm_sec : Z) (tm_min : Z), RET((#ML tm_sec, #ML tm_min)%MLV);
+        (tm_sec : Z) (tm_min : Z), RETV ((#ML tm_sec, #ML tm_min)%MLV);
         True
       }}.
 

--- a/theories/examples/is_eq.v
+++ b/theories/examples/is_eq.v
@@ -75,7 +75,7 @@ Section C_specs.
        "Htok" ∷ na_tok
     }}
       "is_eq" with [x; y]
-    {{ RET (#ML (bool_decide (x = y))); na_tok }}.
+    {{ RETV (#ML (bool_decide (x = y))); na_tok }}.
 
   Lemma is_eq_correct Ψ :
     prims_proto Ψ ||- is_eq_prog :: wrap_proto is_eq_spec_ML.

--- a/theories/examples/listener.v
+++ b/theories/examples/listener.v
@@ -91,7 +91,7 @@ Section Proofs.
     !! interp Δ
     {{ "Hna" ∷ na_tok }}
       "listener_create" with [ #() ]
-    {{ vr, RET vr; na_tok ∗ listener_interp Ψ interp Δ vr }}.
+    {{ vr, RETV vr; na_tok ∗ listener_interp Ψ interp Δ vr }}.
   Definition listener_notify_spec_ML : protocol ML_lang.val Σ :=
     !! interp Δ vn vb
     {{
@@ -100,7 +100,7 @@ Section Proofs.
        "#Hbox" ∷ ▷ listener_interp Ψ interp Δ vb
     }}
       "listener_notify" with [ vn; vb ]
-    {{ RET #(); na_tok }}.
+    {{ RETV #(); na_tok }}.
   Definition listener_listen_spec_ML : protocol ML_lang.val Σ :=
     !! interp Δ vl vb
     {{
@@ -109,7 +109,7 @@ Section Proofs.
        "Hna" ∷ na_tok
     }}
       "listener_listen" with [ vl; vb ]
-    {{ RET #(); na_tok }}.
+    {{ RETV #(); na_tok }}.
   Definition listener_unlisten_spec_ML : protocol ML_lang.val Σ :=
     !! interp Δ vb
     {{
@@ -117,7 +117,7 @@ Section Proofs.
        "Hna" ∷ na_tok
     }}
       "listener_unlisten" with [ vb ]
-    {{ RET #(); na_tok }}.
+    {{ RETV #(); na_tok }}.
 
   Import melocoton.c_lang.primitive_laws melocoton.c_lang.proofmode.
 

--- a/theories/examples/new_boxedint.v
+++ b/theories/examples/new_boxedint.v
@@ -36,7 +36,7 @@ Section FFI_spec.
       {{ True }}
         "caml_new_boxedint" with []
       {{
-        RET((#ML (LitBoxedInt 0))%MLV);
+        RETV ((#ML (LitBoxedInt 0))%MLV);
         True
       }}.
 

--- a/theories/examples/swap_pair.v
+++ b/theories/examples/swap_pair.v
@@ -42,7 +42,7 @@ Definition swap_pair_func : function := Fun [BNamed "x"] (swap_pair_code "x").
 Definition swap_pair_prog : lang_prog C_lang := {[ "swap_pair" := swap_pair_func ]}.
 
 Definition swap_pair_ml_spec : protocol ML_lang.val Σ :=
-  !! v1 v2 {{ True }} "swap_pair" with [ (v1, v2)%MLV ] {{ RET (v2, v1)%MLV; True }}.
+  !! v1 v2 {{ True }} "swap_pair" with [ (v1, v2)%MLV ] {{ RETV (v2, v1)%MLV; True }}.
 
 Lemma swap_pair_correct :
   prims_proto swap_pair_ml_spec ||- swap_pair_prog :: wrap_proto swap_pair_ml_spec.

--- a/theories/examples/swap_variant.v
+++ b/theories/examples/swap_variant.v
@@ -69,7 +69,7 @@ Definition swap_variant_ml_spec : protocol ML_lang.val Σ :=
   !! (v: MLval) r
       {{ ⌜swap_sum v = Some r⌝ }}
         "swap_variant" with [ v ]
-      {{ RET r; True }}.
+      {{ RETV r; True }}.
 
 Lemma swap_variant_correct :
   prims_proto swap_variant_ml_spec ||- swap_variant_prog :: wrap_proto swap_variant_ml_spec.

--- a/theories/examples/zigzag_list.v
+++ b/theories/examples/zigzag_list.v
@@ -82,31 +82,31 @@ Section Proofs.
   Import melocoton.ml_lang.notation.
 
   Definition zigzag_nil_spec_ML : protocol ML_lang.val Σ :=
-    !! {{ True }} "zigzag_nil" with [] {{ vr, RET vr; is_zigzag nil vr }}.
+    !! {{ True }} "zigzag_nil" with [] {{ vr, RETV vr; is_zigzag nil vr }}.
 
   Definition zigzag_cons_spec_ML : protocol ML_lang.val Σ :=
     !! hd tl tlV
     {{ "Htl" ∷ is_zigzag tl tlV }}
       "zigzag_cons" with [ hd; tlV ]
-    {{ vr, RET vr; is_zigzag (hd::tl) vr }}.
+    {{ vr, RETV vr; is_zigzag (hd::tl) vr }}.
 
   Definition zigzag_empty_spec_ML : protocol ML_lang.val Σ :=
     !! lst lstV
     {{ "Htl" ∷ is_zigzag lst lstV }}
       "zigzag_empty" with [lstV]
-    {{ RET #(is_empty lst); is_zigzag lst lstV }}.
+    {{ RETV #(is_empty lst); is_zigzag lst lstV }}.
 
   Definition zigzag_head_spec_ML : protocol ML_lang.val Σ :=
     !! hd tl lstV
     {{ "Htl" ∷ is_zigzag (hd::tl) lstV }}
       "zigzag_head" with [lstV]
-    {{ RET hd; is_zigzag (hd::tl) lstV }}.
+    {{ RETV hd; is_zigzag (hd::tl) lstV }}.
 
   Definition zigzag_tail_spec_ML : protocol ML_lang.val Σ :=
     !! hd tl lstV
     {{ "Htl" ∷ is_zigzag (hd::tl) lstV }}
       "zigzag_tail" with [lstV]
-    {{ tlV, RET tlV;
+    {{ tlV, RETV tlV;
          is_zigzag tl tlV ∗
          (∀ tl', is_zigzag tl' tlV -∗ is_zigzag (hd::tl') lstV) }}.
 
@@ -114,7 +114,7 @@ Section Proofs.
     !! hd tl lstV
     {{ "Htl" ∷ is_zigzag (hd::tl) lstV }}
       "zigzag_pop" with [lstV]
-    {{ tlV, RET tlV; is_zigzag tl tlV ∗ is_zigzag nil lstV }}.
+    {{ tlV, RETV tlV; is_zigzag tl tlV ∗ is_zigzag nil lstV }}.
 
   Import melocoton.c_lang.primitive_laws melocoton.c_lang.proofmode.
 

--- a/theories/interop/prims_proto.v
+++ b/theories/interop/prims_proto.v
@@ -42,13 +42,13 @@ Definition int2val_proto : C_proto :=
   !! θ z
   {{ "HGC" ∷ GC θ }}
     "int2val" with [C_intf.LitV $ C_intf.LitInt $ z]
-  {{ w, RET w; GC θ ∗ ⌜repr_lval θ (Lint z) w⌝ }}.
+  {{ w, RETV w; GC θ ∗ ⌜repr_lval θ (Lint z) w⌝ }}.
 
 Definition val2int_proto : C_proto :=
   !! θ w z
   {{ "HGC" ∷ GC θ ∗ "%Hrepr" ∷ ⌜repr_lval θ (Lint z) w⌝ }}
     "val2int" with [w]
-  {{ RET C_intf.LitV $ C_intf.LitInt $ z; GC θ }}.
+  {{ RETV C_intf.LitV $ C_intf.LitInt $ z; GC θ }}.
 
 Definition registerroot_proto : C_proto :=
   !! θ l v w
@@ -58,13 +58,13 @@ Definition registerroot_proto : C_proto :=
      "%Hrepr" ∷ ⌜repr_lval θ v w⌝
   }}
     "registerroot" with [ C_intf.LitV $ C_intf.LitLoc $ l ]
-  {{ RET C_intf.LitV $ C_intf.LitInt $ 0; GC θ ∗ l ↦roots v }}.
+  {{ RETV C_intf.LitV $ C_intf.LitInt $ 0; GC θ ∗ l ↦roots v }}.
 
 Definition unregisterroot_proto : C_proto :=
   !! θ l v
   {{ "HGC" ∷ GC θ ∗ "Hpto" ∷ l ↦roots v }}
     "unregisterroot" with [ C_intf.LitV $ C_intf.LitLoc $ l ]
-  {{ w, RET C_intf.LitV $ C_intf.LitInt $ 0; GC θ ∗ l ↦C w ∗ ⌜repr_lval θ v w⌝ }}.
+  {{ w, RETV C_intf.LitV $ C_intf.LitInt $ 0; GC θ ∗ l ↦C w ∗ ⌜repr_lval θ v w⌝ }}.
 
 Definition modify_proto : C_proto :=
   !! θ w i v' w' γ mut tg vs
@@ -78,7 +78,7 @@ Definition modify_proto : C_proto :=
      "Hpto" ∷ γ ↦vblk[mut] (tg, vs)
   }}
     "modify" with [ w; C_intf.LitV $ C_intf.LitInt $ i; w' ]
-  {{ RET C_intf.LitV $ C_intf.LitInt $ 0;
+  {{ RETV C_intf.LitV $ C_intf.LitInt $ 0;
      GC θ ∗ γ ↦vblk[mut] (tg, <[Z.to_nat i:=v']> vs)
   }}.
 
@@ -92,7 +92,7 @@ Definition readfield_proto : C_proto :=
      "Hpto" ∷ γ ↦vblk[m]{dq} (tg, vs)
   }}
     "readfield" with [ w; C_intf.LitV $ C_intf.LitInt $ i ]
-  {{ w' v', RET w';
+  {{ w' v', RETV w';
      GC θ ∗
      γ ↦vblk[m]{dq} (tg, vs) ∗
      ⌜vs !! (Z.to_nat i) = Some v'⌝ ∗
@@ -103,7 +103,7 @@ Definition isblock_proto : C_proto :=
   !! θ lv w
   {{ "HGC" ∷ GC θ ∗ "%Hreprw" ∷ ⌜repr_lval θ lv w⌝ }}
     "isblock" with [ w ]
-  {{ RET C_intf.LitV $ C_intf.LitInt
+  {{ RETV C_intf.LitV $ C_intf.LitInt
             (match lv with Lloc _ => 1 | _ => 0 end);
      GC θ
   }}.
@@ -117,7 +117,7 @@ Definition read_tag_proto : C_proto :=
      "Hpto" ∷ lstore_own_elem γ dq bl
   }}
     "read_tag" with [ w ]
-  {{ RET C_intf.LitV $ C_intf.LitInt $ (tag_as_int tg);
+  {{ RETV C_intf.LitV $ C_intf.LitInt $ (tag_as_int tg);
      GC θ ∗ lstore_own_elem γ dq bl
   }}.
 
@@ -129,7 +129,7 @@ Definition length_proto : C_proto :=
      "Hpto" ∷ γ ↦vblk[ a ]{ dq } bl
   }}
     "length" with [ w ]
-  {{ RET C_intf.LitV $ C_intf.LitInt $ length $ snd $ bl;
+  {{ RETV C_intf.LitV $ C_intf.LitInt $ length $ snd $ bl;
      GC θ ∗ γ ↦vblk[ a ]{ dq } bl
   }}.
 
@@ -138,7 +138,7 @@ Definition alloc_proto : C_proto :=
   {{ "HGC" ∷ GC θ ∗ "%Hsz" ∷ ⌜0 ≤ sz⌝%Z }}
     "alloc" with
       [ C_intf.LitV $ C_intf.LitInt $ vblock_tag_as_int $ tg; C_intf.LitV $ C_intf.LitInt $ sz ]
-  {{ θ' γ w, RET w;
+  {{ θ' γ w, RETV w;
      GC θ' ∗
      γ ↦fresh (tg, List.repeat (Lint 0) (Z.to_nat sz)) ∗
      ⌜repr_lval θ' (Lloc γ) w⌝
@@ -148,7 +148,7 @@ Definition alloc_foreign_proto : C_proto :=
   !! θ
   {{ GC θ }}
     "alloc_foreign" with []
-  {{ θ' γ w, RET w; GC θ' ∗ γ ↦foreignO[Mut] None ∗ ⌜repr_lval θ' (Lloc γ) w⌝ }}.
+  {{ θ' γ w, RETV w; GC θ' ∗ γ ↦foreignO[Mut] None ∗ ⌜repr_lval θ' (Lloc γ) w⌝ }}.
 
 Definition write_foreign_proto : C_proto :=
   !! θ γ w wo w'
@@ -158,7 +158,7 @@ Definition write_foreign_proto : C_proto :=
      "Hpto" ∷ γ ↦foreignO[Mut] wo
   }}
     "write_foreign" with [ w; w' ]
-  {{ RET (C_intf.LitV (C_intf.LitInt 0));
+  {{ RETV (C_intf.LitV (C_intf.LitInt 0));
      GC θ ∗ γ ↦foreign[Mut] w'
   }}.
 
@@ -170,7 +170,7 @@ Definition read_foreign_proto : C_proto :=
      "Hpto" ∷ γ ↦foreign[m]{dq} w'
   }}
     "read_foreign" with [ w ]
-  {{ RET w'; GC θ ∗ γ ↦foreign[m]{dq} w' }}.
+  {{ RETV w'; GC θ ∗ γ ↦foreign[m]{dq} w' }}.
 
 Definition callback_proto (Ψ : ML_proto) : C_proto :=
   !! θ w γ w' lv' v' f x e Φ'
@@ -183,14 +183,14 @@ Definition callback_proto (Ψ : ML_proto) : C_proto :=
      "WPcallback" ∷ ▷ WP (App (Val (RecV f x e)) (Val v')) at ⟨∅, Ψ⟩ {{ Φ' }}
   }}
     "callback" with [ w; w' ]
-  {{ θ' vret lvret wret, RET wret;
+  {{ θ' vret lvret wret, RETV wret;
      GC θ' ∗ Φ' (OVal vret) ∗ lvret ~~ vret ∗ ⌜repr_lval θ' lvret wret⌝
   }}.
 
 Definition main_proto (Φ' : Z → Prop) (Pinit : iProp Σ) : C_proto :=
   !! {{ "Hat_init" ∷ at_init ∗ "Hinitial_resources" ∷ Pinit }}
     "main" with []
-  {{ x, RET code_int x; ⌜Φ' x⌝ }}.
+  {{ x, RETV code_int x; ⌜Φ' x⌝ }}.
 
 Definition prim_proto (p : prim) (Ψ : ML_proto) : C_proto :=
   match p with

--- a/theories/language_commons.v
+++ b/theories/language_commons.v
@@ -26,19 +26,36 @@ Notation "'WP' e 'at' s {{ o , Q } }" := (wp s ⊤ e%E (λ o, Q))
 
 Notation "'{{{' P } } } e 'at' s {{{ x .. y , 'RET' pat ; Q } } }" :=
   (□ ∀ Φ,
-      P -∗ ▷ (∀ x, .. (∀ y, Q -∗ Φ (OVal pat%V)) .. ) -∗ WP e @ s; ⊤ {{ Φ }})%I
+      P -∗ ▷ (∀ x, .. (∀ y, Q -∗ Φ pat%V) .. ) -∗ WP e @ s; ⊤ {{ Φ }})%I
     (at level 20, x closed binder, y closed binder,
      format "'[hv' {{{  '[' P  ']' } } }  '/  ' e  '/'  'at'  s  '/' {{{  '[' x  ..  y ,  RET  pat ;  '/' Q  ']' } } } ']'") : bi_scope.
 
 Notation "'{{{' P } } } e 'at' s {{{ 'RET' pat ; Q } } }" :=
-  (□ ∀ Φ, P -∗ ▷ (Q -∗ Φ (OVal pat%V)) -∗ WP e @ s; ⊤ {{ Φ }})%I
+  (□ ∀ Φ, P -∗ ▷ (Q -∗ Φ pat%V) -∗ WP e @ s; ⊤ {{ Φ }})%I
     (at level 20,
      format "'[hv' {{{  '[' P  ']' } } }  '/  ' e  '/'  'at'  s  '/' {{{  '[' RET  pat ;  '/' Q  ']' } } } ']'") : bi_scope.
 
 
 Notation "'{{{' P } } } e 'at' s {{{ x .. y , 'RET' pat ; Q } } }" :=
-  (∀ Φ, P -∗ ▷ (∀ x, .. (∀ y, Q -∗ Φ (OVal pat%V)) .. ) -∗ WP e @ s; ⊤ {{ Φ }}) : stdpp_scope.
+  (∀ Φ, P -∗ ▷ (∀ x, .. (∀ y, Q -∗ Φ pat%V) .. ) -∗ WP e @ s; ⊤ {{ Φ }}) : stdpp_scope.
 Notation "'{{{' P } } } e 'at' s {{{ 'RET' pat ; Q } } }" :=
+  (∀ Φ, P -∗ ▷ (Q -∗ Φ pat%V) -∗ WP e @ s; ⊤ {{ Φ }}) : stdpp_scope.
+
+Notation "'{{{' P } } } e 'at' s {{{ x .. y , 'RETV' pat ; Q } } }" :=
+  (□ ∀ Φ,
+      P -∗ ▷ (∀ x, .. (∀ y, Q -∗ Φ (OVal pat%V)) .. ) -∗ WP e @ s; ⊤ {{ Φ }})%I
+    (at level 20, x closed binder, y closed binder,
+     format "'[hv' {{{  '[' P  ']' } } }  '/  ' e  '/'  'at'  s  '/' {{{  '[' x  ..  y ,  RETV  pat ;  '/' Q  ']' } } } ']'") : bi_scope.
+
+Notation "'{{{' P } } } e 'at' s {{{ 'RETV' pat ; Q } } }" :=
+  (□ ∀ Φ, P -∗ ▷ (Q -∗ Φ (OVal pat%V)) -∗ WP e @ s; ⊤ {{ Φ }})%I
+    (at level 20,
+     format "'[hv' {{{  '[' P  ']' } } }  '/  ' e  '/'  'at'  s  '/' {{{  '[' RETV  pat ;  '/' Q  ']' } } } ']'") : bi_scope.
+
+
+Notation "'{{{' P } } } e 'at' s {{{ x .. y , 'RETV' pat ; Q } } }" :=
+  (∀ Φ, P -∗ ▷ (∀ x, .. (∀ y, Q -∗ Φ (OVal pat%V)) .. ) -∗ WP e @ s; ⊤ {{ Φ }}) : stdpp_scope.
+Notation "'{{{' P } } } e 'at' s {{{ 'RETV' pat ; Q } } }" :=
   (∀ Φ, P -∗ ▷ (Q -∗ Φ (OVal pat%V)) -∗ WP e @ s; ⊤ {{ Φ }}) : stdpp_scope.
 
 (** Protocols *)
@@ -211,26 +228,51 @@ Notation "Ψ 'on' fns" := (proto_on Ψ fns) (at level 10).
 
 Notation "'!!' x .. y '{{' P } } f 'with' l {{ u .. v , 'RET' pat ; Q } }" :=
   (λ fn args Φ, "->" ∷ ⌜fn = f⌝ ∗ (∃ x, .. (∃ y, "->" ∷ ⌜args = l⌝ ∗ "ProtoPre" ∷ P ∗
-    "Cont" ∷ ▷ (∀ u, .. (∀ v, Q -∗ Φ (OVal pat)) ..)) ..))%I
+    "Cont" ∷ ▷ (∀ u, .. (∀ v, Q -∗ Φ pat) ..)) ..))%I
   (at level 20, x closed binder, y closed binder, u closed binder, v closed binder,
    format "'[hv' !!  x  ..  y  {{  '[' P  ']' } }  '/  ' f  'with'  l  '/'  {{  '[' u  ..  v ,  RET  pat ;  '/' Q  ']' } } ']'").
 
 Notation "'!!' '{{' P } } f 'with' l {{ u .. v , 'RET' pat ; Q } }" :=
   (λ fn args Φ, "->" ∷ ⌜fn = f⌝ ∗ ("->" ∷ ⌜args = l⌝ ∗ "ProtoPre" ∷ P ∗
-    "Cont" ∷ ▷ (∀ u, .. (∀ v, Q -∗ Φ (OVal pat)) ..)))%I
+    "Cont" ∷ ▷ (∀ u, .. (∀ v, Q -∗ Φ pat) ..)))%I
   (at level 20, u closed binder, v closed binder,
    format "'[hv' !!  {{  '[' P  ']' } }  '/  ' f  'with'  l  '/'  {{  '[' u  ..  v ,  RET  pat ;  '/' Q  ']' } } ']'").
 
 Notation "'!!' x .. y '{{' P } } f 'with' l {{ 'RET' pat ; Q } }" :=
   (λ fn args Φ, "->" ∷ ⌜fn = f⌝ ∗ (∃ x, .. (∃ y, "->" ∷ ⌜args = l⌝ ∗ "ProtoPre" ∷ P ∗
-    "Cont" ∷ ▷ (Q -∗ Φ (OVal pat))) ..))%I
+    "Cont" ∷ ▷ (Q -∗ Φ pat)) ..))%I
   (at level 20, x closed binder, y closed binder,
    format "'[hv' !!  x  ..  y  {{  '[' P  ']' } }  '/  ' f  'with'  l  '/'  {{  '[' RET  pat ;  '/' Q  ']' } } ']'").
 
 Notation "'!!' '{{' P } } f 'with' l {{ 'RET' pat ; Q } }" :=
   (λ fn args Φ, "->" ∷ ⌜fn = f⌝ ∗ ("->" ∷ ⌜args = l⌝ ∗ "ProtoPre" ∷ P ∗
-    "Cont" ∷ ▷ (Q -∗ Φ (OVal pat))))%I
+    "Cont" ∷ ▷ (Q -∗ Φ pat)))%I
   (at level 20,
    format "'[hv' !!  {{  '[' P  ']' } }  '/  ' f  'with'  l  '/'  {{  '[' RET  pat ;  '/' Q  ']' } } ']'").
+
+
+Notation "'!!' x .. y '{{' P } } f 'with' l {{ u .. v , 'RETV' pat ; Q } }" :=
+  (λ fn args Φ, "->" ∷ ⌜fn = f⌝ ∗ (∃ x, .. (∃ y, "->" ∷ ⌜args = l⌝ ∗ "ProtoPre" ∷ P ∗
+    "Cont" ∷ ▷ (∀ u, .. (∀ v, Q -∗ Φ (OVal pat)) ..)) ..))%I
+  (at level 20, x closed binder, y closed binder, u closed binder, v closed binder,
+   format "'[hv' !!  x  ..  y  {{  '[' P  ']' } }  '/  ' f  'with'  l  '/'  {{  '[' u  ..  v ,  RETV  pat ;  '/' Q  ']' } } ']'").
+
+Notation "'!!' '{{' P } } f 'with' l {{ u .. v , 'RETV' pat ; Q } }" :=
+  (λ fn args Φ, "->" ∷ ⌜fn = f⌝ ∗ ("->" ∷ ⌜args = l⌝ ∗ "ProtoPre" ∷ P ∗
+    "Cont" ∷ ▷ (∀ u, .. (∀ v, Q -∗ Φ (OVal pat)) ..)))%I
+  (at level 20, u closed binder, v closed binder,
+   format "'[hv' !!  {{  '[' P  ']' } }  '/  ' f  'with'  l  '/'  {{  '[' u  ..  v ,  RETV  pat ;  '/' Q  ']' } } ']'").
+
+Notation "'!!' x .. y '{{' P } } f 'with' l {{ 'RETV' pat ; Q } }" :=
+  (λ fn args Φ, "->" ∷ ⌜fn = f⌝ ∗ (∃ x, .. (∃ y, "->" ∷ ⌜args = l⌝ ∗ "ProtoPre" ∷ P ∗
+    "Cont" ∷ ▷ (Q -∗ Φ (OVal pat))) ..))%I
+  (at level 20, x closed binder, y closed binder,
+   format "'[hv' !!  x  ..  y  {{  '[' P  ']' } }  '/  ' f  'with'  l  '/'  {{  '[' RETV  pat ;  '/' Q  ']' } } ']'").
+
+Notation "'!!' '{{' P } } f 'with' l {{ 'RETV' pat ; Q } }" :=
+  (λ fn args Φ, "->" ∷ ⌜fn = f⌝ ∗ ("->" ∷ ⌜args = l⌝ ∗ "ProtoPre" ∷ P ∗
+    "Cont" ∷ ▷ (Q -∗ Φ (OVal pat))))%I
+  (at level 20,
+   format "'[hv' !!  {{  '[' P  ']' } }  '/  ' f  'with'  l  '/'  {{  '[' RETV  pat ;  '/' Q  ']' } } ']'").
 
 Ltac iNamedProto H := repeat (iNamed H); iNamed "ProtoPre".

--- a/theories/ml_lang/primitive_laws.v
+++ b/theories/ml_lang/primitive_laws.v
@@ -154,7 +154,7 @@ Qed.
 Lemma wp_allocN pe v n :
   (0 ≤ n)%Z →
   {{{ True }}} AllocN (Val $ LitV $ LitInt n) (Val v) at pe
-  {{{ l, RET LitV (LitLoc l); l ↦∗ (replicate (Z.to_nat n) v) ∗ meta_token l ⊤ }}}.
+  {{{ l, RETV LitV (LitLoc l); l ↦∗ (replicate (Z.to_nat n) v) ∗ meta_token l ⊤ }}}.
 Proof.
   iIntros (Hn Φ) "_ HΦ". iApply wp_lift_atomic_head_step; first done.
   iIntros (σ1) "Hσ". iModIntro. iSplit; first (destruct n; eauto with lia head_step).
@@ -166,7 +166,7 @@ Qed.
 
 Lemma wp_alloc pe v :
   {{{ True }}} Alloc (Val v) at pe
-  {{{ l, RET LitV (LitLoc l); l ↦M v ∗ meta_token l ⊤ }}}.
+  {{{ l, RETV LitV (LitLoc l); l ↦M v ∗ meta_token l ⊤ }}}.
 Proof.
   iIntros (HΦ) "_ HΦ". by iApply wp_allocN.
 Qed.
@@ -174,7 +174,7 @@ Qed.
 Lemma wp_allocN_wrong_size pe v n :
   (n < 0)%Z →
   {{{ True }}} AllocN (Val $ LitV $ LitInt n) (Val v) at pe
-  {{{ RET v; False }}}.
+  {{{ RETV v; False }}}.
 Proof.
   iIntros (Hn Φ) "_ HΦ". iLöb as "IH".
   iApply wp_lift_step_fupd; first done.
@@ -191,7 +191,7 @@ Lemma wp_loadN pe l i dq vs v :
   (0 ≤ i)%Z →
   vs !! Z.to_nat i = Some v →
   {{{ ▷ l ↦∗{dq} vs }}} LoadN (Val $ LitV $ LitLoc l) (Val $ LitV $ LitInt i) at pe
-  {{{ RET v; l ↦∗{dq} vs }}}.
+  {{{ RETV v; l ↦∗{dq} vs }}}.
 Proof.
   iIntros (Hi Hv Φ) ">Hl HΦ". iApply wp_lift_atomic_head_step; first done.
   iIntros (σ1) "Hσ !>". iDestruct (gen_heap_valid with "Hσ Hl") as %?.
@@ -205,7 +205,7 @@ Qed.
 Lemma wp_loadN_oob pe l i dq vs :
   (i < 0 ∨ length vs ≤ i)%Z →
   {{{ ▷ l ↦∗{dq} vs }}} LoadN (Val $ LitV $ LitLoc l) (Val $ LitV $ LitInt i) at pe
-  {{{ v, RET v; False }}}.
+  {{{ v, RETV v; False }}}.
 Proof.
   iIntros (Hi Φ) ">Hl HΦ". iLöb as "IH".
   iApply wp_lift_step_fupd; first done.
@@ -222,7 +222,7 @@ Qed.
 
 Lemma wp_load pe l dq v :
   {{{ ▷ l ↦M{dq} v }}} Load (Val $ LitV $ LitLoc l) at pe
-  {{{ RET v; l ↦M{dq} v }}}.
+  {{{ RETV v; l ↦M{dq} v }}}.
 Proof.
   iIntros (Φ) ">Hl HΦ". iApply (wp_loadN with "Hl"); try done.
 Qed.
@@ -230,7 +230,7 @@ Qed.
 Lemma wp_storeN pe l i vs w :
   (0 ≤ i < length vs)%Z →
   {{{ ▷ l ↦∗ vs }}} StoreN (Val $ LitV $ LitLoc l) (Val $ LitV $ LitInt i) (Val w) at pe
-  {{{ RET LitV LitUnit; l ↦∗ <[ Z.to_nat i := w ]> vs }}}.
+  {{{ RETV LitV LitUnit; l ↦∗ <[ Z.to_nat i := w ]> vs }}}.
 Proof.
   iIntros (Hi Φ) ">Hl HΦ". iApply wp_lift_atomic_head_step; first done.
   iIntros (σ1) "Hσ !>". iDestruct (gen_heap_valid with "Hσ Hl") as %?.
@@ -247,7 +247,7 @@ Qed.
 Lemma wp_storeN_oob pe l i vs w :
   (i < 0 ∨ length vs ≤ i)%Z →
   {{{ ▷ l ↦∗ vs }}} StoreN (Val $ LitV $ LitLoc l) (Val $ LitV $ LitInt i) (Val w) at pe
-  {{{ v, RET v; False }}}.
+  {{{ v, RETV v; False }}}.
 Proof.
   iIntros (Hi Φ) ">Hl HΦ". iLöb as "IH".
   iApply wp_lift_step_fupd; first done.
@@ -265,14 +265,14 @@ Qed.
 
 Lemma wp_store pe l v w :
   {{{ ▷ l ↦M v }}} Store (Val $ LitV $ LitLoc l) (Val w) at pe
-  {{{ RET LitV LitUnit; l ↦M w }}}.
+  {{{ RETV LitV LitUnit; l ↦M w }}}.
 Proof.
   iIntros (Φ) "Hl HΦ". by iApply (wp_storeN with "Hl").
 Qed.
 
 Lemma wp_length pe l dq vs :
   {{{ ▷ l ↦∗{dq} vs }}} Length (Val $ LitV $ LitLoc l) at pe
-  {{{ RET LitV $ LitInt (length vs); l ↦∗{dq} vs }}}.
+  {{{ RETV LitV $ LitInt (length vs); l ↦∗{dq} vs }}}.
 Proof.
   iIntros (Φ) ">Hl HΦ". iApply wp_lift_atomic_head_step; first done.
   iIntros (σ1) "Hσ !>". iDestruct (gen_heap_valid with "Hσ Hl") as %?.


### PR DESCRIPTION
Duplicate WP notation with RETV (Oval implicit)