### PR TITLE
Outcome in interop

### DIFF
--- a/theories/c_interop/rules.v
+++ b/theories/c_interop/rules.v
@@ -10,7 +10,7 @@ From iris.prelude Require Import options.
 (* Derived WP rules for C<->ML interop.
 
    These follow from the generic rules of the wrapper (in interop/) that work
-r  for any language obeying the C interface (c_interface/) -- specialized to our
+   for any language obeying the C interface (c_interface/) -- specialized to our
    concrete C language (c_lang/). *)
 
 Section Laws.

--- a/theories/c_interop/rules.v
+++ b/theories/c_interop/rules.v
@@ -10,7 +10,7 @@ From iris.prelude Require Import options.
 (* Derived WP rules for C<->ML interop.
 
    These follow from the generic rules of the wrapper (in interop/) that work
-   for any language obeying the C interface (c_interface/) -- specialized to our
+r  for any language obeying the C interface (c_interface/) -- specialized to our
    concrete C language (c_lang/). *)
 
 Section Laws.
@@ -317,11 +317,11 @@ Lemma wp_callback p ΨML Ψ θ w γ f x e lv' w' v' Φ :
       (▷ WP (App (ML_lang.Val (RecV f x e)) (ML_lang.Val v')) at ⟨∅, ΨML⟩ {{ Φ }})
   }}}
     (call: &"callback" with (Val w, Val w'))%CE at ⟨p, Ψ⟩
-  {{{ θ' vret lvret wret, RETV wret;
+  {{{ θ' vret lvret wret, RET wret;
         GC θ' ∗
-        Φ (OVal vret) ∗
-        lvret ~~ vret ∗
-        ⌜repr_lval θ' lvret wret⌝ }}}.
+        Φ vret ∗
+        lvret ~~ₒ vret ∗
+        ⌜repr_lval_out θ' lvret wret⌝ }}}.
 Proof.
   intros Hp Hproto **. iIntros "(? & ? & ? & ?) Cont".
   wp_pures. wp_extern; first done.
@@ -329,7 +329,8 @@ Proof.
   rewrite /callback_proto /named. iSplit; first done.
   do 10 iExists _. iFrame.
   do 2 (iSplit; first by eauto with lia). iIntros "!>" (? ? ? ?) "(? & ? & ? & %)".
-  iApply wp_outcome; eauto. iApply "Cont"; eauto. by iFrame.
+  iApply wp_outcome; first apply to_of_outcome.
+  iApply "Cont"; by iFrame.
 Qed.
 
 Lemma wp_main p Ψ Φ P :

--- a/theories/examples/add.v
+++ b/theories/examples/add.v
@@ -57,9 +57,10 @@ Proof.
   iIntros "HGC". wp_pures.
 
   wp_apply (wp_int2val with "HGC"); auto.
-  iIntros (w) "(HGC&Hr)".
+  iIntros (w) "(HGC&%Hr)".
 
-  iApply "HΦ". iApply ("Return" with "HGC [Cont] []"); eauto.
+  iApply "HΦ".
+  iApply ("Return" $! _ _ (OVal (Lint (x + 1))) with "HGC [Cont] []"); eauto.
   - by iApply "Cont".
   - cbn. done.
 Qed.

--- a/theories/examples/box.v
+++ b/theories/examples/box.v
@@ -145,7 +145,8 @@ Section Proofs.
     iMod (na_inv_alloc logrel_nais _ _ (box_invariant_2 ℓ (interp_arrow ⟨ ∅ , Ψ ⟩ interp interp_unit Δ)) with "[Hℓ0]") as "#Hinv2".
     { iNext. iRight. iFrame. }
     iMod (freeze_foreign_to_immut γ θ1 _ with "[$]") as "(HGC&#Hγfgn)".
-    iModIntro. iApply "Cont2". iApply ("Return" $! θ1 (#(LitForeign γ)) with "HGC [-] [] []").
+    iModIntro. iApply "Cont2".
+    iApply ("Return" $! θ1 (OVal #(LitForeign γ)) (OVal (Lloc γ)) with "HGC [-] [] []").
     2,3: done.
     iApply "Cont". iFrame "Hna". iExists γ, ℓ.
     iSplit; first done. 
@@ -193,11 +194,12 @@ Section Proofs.
       wp_apply (wp_callback with "[$HGC $Hlv2 Hna]"); [done..| |].
       { iSplit; first iApply "Hlv1".
         iNext. iApply ("Hcall" with "Hv1 Hna"). }
-      iIntros (θ' vret lvret wret) "(HGC & ((%v&Hv&->)&Hna) & _)".
+      iIntros (θ' vret lvret wret) "(HGC & ((%v&->&->)&Hna) & (H & %Hrepr))".
+      destruct lvret. cbn. inversion Hrepr.
       wp_pures.
       wp_apply (wp_int2val with "HGC"); [done..|].
       iIntros (w0) "(HGC&%Hw0)". iApply "Cont2".
-      iApply ("Return" with "HGC (Cont Hna) [//] [//]").
+      iApply ("Return" $! _ _ (OVal (Lint 0)) with "HGC (Cont Hna) [//] [//]").
     - wp_apply (wp_load with "Hℓ0"). iIntros "Hℓ0".
       wp_pures.
       iMod ("Hclose2" with "[$Hna Hℓ0]") as "Hna".
@@ -206,7 +208,7 @@ Section Proofs.
       { iNext. iExists _, _. iFrame "Hℓ1 Hvn Hsimvn". }
       wp_apply (wp_int2val with "HGC"); [done..|].
       iIntros (w0) "(HGC&%Hw0)". iApply "Cont2".
-      iApply ("Return" with "HGC (Cont Hna) [//] [//]").
+      iApply ("Return" $! _ _ (OVal (Lint 0)) with "HGC (Cont Hna) [//] [//]").
   Qed.
 
   Lemma box_listen_correct :
@@ -250,7 +252,7 @@ Section Proofs.
       destruct v; wp_pures.
       wp_apply (wp_int2val with "HGC"); [done..|].
       iIntros (w0) "(HGC&%Hw0)". iApply "Cont2".
-      iApply ("Return" with "HGC (Cont Hna) [//] [//]").
+      iApply ("Return" $! _ _ (OVal (Lint 0)) with "HGC (Cont Hna) [//] [//]").
   Qed.
 
   End InPsi.

--- a/theories/examples/compression/buffers_proof_alloc.v
+++ b/theories/examples/compression/buffers_proof_alloc.v
@@ -135,7 +135,7 @@ Section Proofs.
     iMod (bufToML with "HGC Hbuf") as "(HGC&%vv&Hbuffer&#Hsim)".
     iModIntro. iApply "HΦ".
      rewrite -(_: z = Z.to_nat z); last lia.
-    iApply ("Return" with "HGC (HCont Hbuffer) Hsim [//]").
+    iApply ("Return" $! θ' (OVal vv) (OVal lv) with "HGC (HCont Hbuffer) Hsim [//]").
   Qed.
 
 End Proofs.

--- a/theories/examples/compression/buffers_proof_free.v
+++ b/theories/examples/compression/buffers_proof_free.v
@@ -86,7 +86,7 @@ Section Proofs.
     }
     iModIntro.
     iApply "HΦ".
-    iApply ("Return" $! _ (#ML ())%MLV with "HGC [-] [//] [//]").
+    iApply ("Return" $! _ (OVal (#ML ()))%MLV (OVal (Lint 0)) with "HGC [-] [//] [//]").
     iApply ("HCont" with "[//] Hγusedref [$]").
   Qed.
 

--- a/theories/examples/compression/buffers_proof_get.v
+++ b/theories/examples/compression/buffers_proof_get.v
@@ -56,7 +56,7 @@ Section Proofs.
     iIntros (o) "(%w&->&HGC&%Hww)".
     iMod (bufToML_fixed with "HGC [Hγusedref HContent Hγfgnpto Hℓbuf] Hsimb") as "(HGC&HBuffer)"; last first.
     { iModIntro. iApply "HΦ".
-      iApply ("Return" with "HGC (HCont HBuffer) [//] [//]"). }
+      iApply ("Return" $! _ _ (OVal (Lint res)) with "HGC (HCont HBuffer) [//] [//]"). }
     { do 5 iExists _. iSplit; first done. iFrameNamed.
       do 1 iExists _. iFrameNamed. done. }
   Qed.

--- a/theories/examples/compression/buffers_proof_update.v
+++ b/theories/examples/compression/buffers_proof_update.v
@@ -104,7 +104,8 @@ Section Proofs.
         iNext. by iApply ("HWP" with "[] [] HΨ"). } cbn.
       cbn.
       iIntros (θ' vret lvret wret) "(HGC&(%zret&%Ho&HΦz&HΨframe&HBuffer)&Hv&%Hzrep)".
-      inversion Ho. subst. cbn. iRevert "Hv". iIntros "%Hv". subst.
+      inversion Ho. subst. destruct lvret. inversion Hzrep; subst.
+      cbn. iRevert "Hv". iIntros "%Hv". subst.
       wp_apply (wp_val2int with "HGC"); try done.
       iIntros "HGC".
       iDestruct "HBuffer" as "(%ℓML0&%&%&%Heq&HℓbufML&Hbuf)". simplify_eq. unfold named.
@@ -195,7 +196,8 @@ Section Proofs.
     iIntros "HGC"; wp_pure _.
     wp_apply (wp_CAMLunregister1 with "[$HGC $Hℓbf]"); [done..|].
     iIntros "HGC"; wp_pure _.
-    iModIntro. iApply "HΦ". iApply ("Return" with "HGC (HCont HΨ) [//] [//]").
+    iModIntro. iApply "HΦ".
+    iApply ("Return" $! _ _ (OVal (Lint 0)) with "HGC (HCont HΨ) [//] [//]").
   Qed.
 
 End Proofs.

--- a/theories/examples/compression/buffers_proofs_compr.v
+++ b/theories/examples/compression/buffers_proofs_compr.v
@@ -46,7 +46,8 @@ Section Proofs.
     iSplit; first done. iNext. wp_finish.
     wp_apply (wp_int2val with "HGC"); [mdone..|].
     iIntros (w) "(HGC&%Hrepr)".
-    iApply "HΦ". iApply ("Return" with "HGC HCont [//] [//]").
+    iApply "HΦ".
+    iApply ("Return" $! _ _ (OVal (Lint (n + (n + 0))%nat)) with "HGC HCont [//] [//]").
   Qed.
 
   Lemma wrap_compress_correct Ψ :
@@ -132,11 +133,11 @@ Section Proofs.
       wp_pure _. iApply (wp_post_mono _ _ _ 
         (λ o, ∃ w, ⌜o = OVal w⌝ ∗ GC θ ∗ ⌜repr_lval θ (Lint 1) w⌝)%I with "[HGC]").
       1: wp_apply (wp_int2val with "HGC"); [mdone..|iIntros (w) "H"; iExists w; iFrame; try done].
-      iIntros (o) "(%w&->&HGC&Hreprw1)".
+      iIntros (o) "(%w&->&HGC&%Hreprw1)".
       iMod (bufToML_fixed with "HGC [Hγusedref Hγfgnpto Hℓbuf Hℓbufuninit HContent] Hsim1") as "(HGC&HBuf1)"; last first.
       1: iMod (bufToML_fixed with "HGC [Hγusedref2 Hγfgnpto2 Hℓbuf2 HContent2] Hsim2") as "(HGC&HBuf2)"; last first.
       1: iApply "HΦ".
-      1: iApply ("Return" $! _ (#ML true) _ (w) with "HGC (HCont HBuf1 HBuf2) [//]"); try done.
+      1: iApply ("Return" $! _ (OVal (#ML true)) (OVal (Lint 1)) (OVal w) with "HGC (HCont HBuf1 HBuf2) [//]"); try done.
       { iExists _, _, _, _, _. unfold named.
         iSplit; first done.
         change (Z.to_nat 0) with 0; cbn.

--- a/theories/examples/gmtime.v
+++ b/theories/examples/gmtime.v
@@ -133,7 +133,7 @@ Section FFI_spec.
 
     (* Return *)
     wp_apply (load_from_root with "[$HGC $Hℓ]").
-    iIntros (w4) "(Hℓ&HGC&Hγ4)". wp_pures.
+    iIntros (w4) "(Hℓ&HGC&%Hγ4)". wp_pures.
 
     wp_apply (wp_unregisterroot with "[$HGC $Hℓ]"); try eauto.
     iIntros (w5) "(HGC&hℓ&%Hγ5)". wp_pures.
@@ -143,10 +143,10 @@ Section FFI_spec.
 
     iModIntro.
     iApply "HΦ".
-    iApply ("Return" with "[$HGC] [Cont] []").
+    iApply ("Return" $! θ' (OVal _) (OVal (Lloc γ')) with "[$HGC] [Cont] []").
     - by iApply "Cont".
     - cbn. iExists γ'. iExists _, _. iSplit; try eauto.
-    - eauto.
+    - iPureIntro. econstructor. eauto.
 Qed.
 
 End FFI_spec.

--- a/theories/examples/listener.v
+++ b/theories/examples/listener.v
@@ -149,7 +149,8 @@ Section Proofs.
     iMod (na_inv_alloc logrel_nais _ _ (listener_invariant a _) with "[Ha]") as "#Hinv".
     { iNext. iRight. iFrame "Ha". }
     iMod (freeze_foreign_to_immut γ θ1 _ with "[$]") as "(HGC&#Hγfgn')".
-    iModIntro. iApply "Cont2". iApply ("Return" $! θ1 (#(LitForeign γ)) with "HGC [-] [] []").
+    iModIntro. iApply "Cont2".
+    iApply ("Return" $! θ1 (OVal #(LitForeign γ)) (OVal (Lloc γ)) with "HGC [-] [] []").
     2,3: done.
     iApply "Cont". iFrame "Hna". iExists γ, a.
     iSplit; first done. iSplitL.
@@ -189,10 +190,11 @@ Section Proofs.
         + iExists _, _, _; by repeat iSplit. }
       wp_apply (wp_callback with "[$HGC $Hclos $Hsimvn Hinterp Hna]"); [try done..|].
       { iNext. by iApply "Hinterp". }
-      iIntros (θ' vret lvret wret) "(HGC & ((%v&Ho&Hi)&Hna) & Hsimret & %)".
+      iIntros (θ' vret lvret wret) "(HGC & ((%v&->&Hi)&Hna) & Hsimret & %)".
+      destruct lvret. cbn. inversion H2.
       wp_pures. wp_apply (wp_int2val with "HGC"); [done..|].
       iIntros (?) "[HGC %HH]". inversion HH; simplify_eq.
-      iApply "Cont2". cbn. iApply ("Return" with "HGC [Cont Hna] [] []").
+      iApply "Cont2". cbn. iApply ("Return" $! _ _ (OVal (Lint 0)) with "HGC [Cont Hna] [] []").
       1: by iApply "Cont". 1,2: by iPureIntro.
     - wp_apply (wp_load with "[$Hnull]"). iIntros "Hnull".
       wp_pures.
@@ -200,7 +202,8 @@ Section Proofs.
       { iNext. iRight. iFrame. }
       wp_apply (wp_int2val with "HGC"); [done..|].
       iIntros (?) "[HGC %HH]". inversion HH; simplify_eq.
-      iApply "Cont2". iApply ("Return" with "HGC [Cont Hna] [] []").
+      iApply "Cont2".
+      iApply ("Return" $! _ _ (OVal (Lint 0)) with "HGC [Cont Hna] [] []").
       1: by iApply "Cont". 1,2: by iPureIntro.
   Qed.
 
@@ -237,7 +240,8 @@ Section Proofs.
       iMod ("Hclose" with "[$Hna Ha]") as "Hna".
       { iNext. iLeft. iExists _, _. iFrame "Ha Hvl Hsimvl". }
       wp_apply (wp_int2val with "HGC"); [done..|]. iIntros (?) "[HGC %]".
-      iApply "Cont2". iApply ("Return" with "HGC [Cont Hna]").
+      iApply "Cont2".
+      iApply ("Return" $! _ _ (OVal (Lint 0)) with "HGC [Cont Hna]").
       1: by iApply "Cont". 1,2: by iPureIntro.
     - wp_pures.
       wp_apply (wp_load with "Hnull"); iIntros "Hnull".
@@ -250,7 +254,8 @@ Section Proofs.
       iMod ("Hclose" with "[$Hna Hroot]") as "Hna".
       { iNext. iLeft. iExists _, _. iFrame "Hroot Hvl Hsimvl". }
       wp_apply (wp_int2val with "HGC"); [done..|]. iIntros (?) "[HGC %]".
-      iApply "Cont2". iApply ("Return" with "HGC [Cont Hna]").
+      iApply "Cont2".
+      iApply ("Return" $! _ _ (OVal (Lint 0)) with "HGC [Cont Hna]").
       1: by iApply "Cont". 1,2: by iPureIntro.
   Qed.
 
@@ -285,7 +290,8 @@ Section Proofs.
       iMod ("Hclose" with "[$Hna Ha]") as "Hna".
       { iNext. iRight. iFrame. } wp_pures.
       wp_apply (wp_int2val with "HGC"); [done..|]. iIntros (?) "[HGC %]".
-      iApply "Cont2". iApply ("Return" with "HGC [Cont Hna]").
+      iApply "Cont2".
+      iApply ("Return" $! _ _ (OVal (Lint 0)) with "HGC [Cont Hna]").
       1: by iApply "Cont". 1,2: by iPureIntro.
     - wp_pures.
       wp_apply (wp_load with "Hnull"); iIntros "Hnull".
@@ -295,7 +301,8 @@ Section Proofs.
       iMod ("Hclose" with "[$Hna Hnull]") as "Hna".
       { iNext. iRight. iFrame. }
       wp_apply (wp_int2val with "HGC"); [done..|]. iIntros (?) "[HGC %]".
-      iApply "Cont2". iApply ("Return" with "HGC [Cont Hna]").
+      iApply "Cont2".
+      iApply ("Return" $! _ _ (OVal (Lint 0)) with "HGC [Cont Hna]").
       1: by iApply "Cont". 1,2: by iPureIntro.
   Qed.
 

--- a/theories/examples/new_boxedint.v
+++ b/theories/examples/new_boxedint.v
@@ -65,7 +65,7 @@ Section FFI_spec.
 
     iModIntro.
     iApply "HΦ".
-    iApply ("Return" with "[$HGC] [Cont] []").
+    iApply ("Return" $! _ _ (OVal (Lloc γ)) with "[$HGC] [Cont] []").
     - by iApply "Cont".
     - cbn. iExists γ. iSplit; try eauto.
     - eauto.

--- a/theories/examples/swap_pair.v
+++ b/theories/examples/swap_pair.v
@@ -126,7 +126,8 @@ Proof.
   (* Finish, convert the new points-to to an immutable pointsto *)
   iMod (freeze_to_immut γnew _ θ' with "[$]") as "(HGC&#Hnew)".
 
-  iModIntro. iApply "HΦ". iApply ("Return" with "HGC [Cont] [] []").
+  iModIntro. iApply "HΦ".
+  iApply ("Return" $! θ' _ (OVal (Lloc γnew)) with "HGC [Cont] [] []").
   - by iApply "Cont".
   - cbn. do 3 iExists _. iFrame "Hnew Hlv1 Hlv2". done.
   - done.

--- a/theories/examples/swap_variant.v
+++ b/theories/examples/swap_variant.v
@@ -147,7 +147,8 @@ Proof.
   iMod (freeze_to_immut γnew _ θ' with "[$]") as "(HGC&#Hnew)".
   change (Z.to_nat 1) with 1; cbn.
 
-  iModIntro. iApply "HΦ". iApply ("Return" with "HGC [Cont] [ProtoPre]").
+  iModIntro. iApply "HΦ".
+  iApply ("Return" $! _ _ (OVal (Lloc γnew)) with "HGC [Cont] [ProtoPre]").
   - by iApply "Cont".
   - destruct v; iDestruct "ProtoPre" as "%Hptpair"; try done;
     cbn in *; simplify_eq;

--- a/theories/examples/zigzag_list.v
+++ b/theories/examples/zigzag_list.v
@@ -289,7 +289,7 @@ Section Proofs.
     { iNext. cbn. rewrite !loc_add_0. iFrame. }
     iIntros "_". wp_pures. iModIntro.
     iApply "Cont2".
-    iApply ("Return" with "HGC (Cont [$Hrec Hγfgn])"); [|done..].
+    iApply ("Return" $! θ (OVal Vlst) (OVal lv2) with "HGC (Cont [$Hrec Hγfgn])"); [|done..].
     iExists _, _; iSplit; first done. iFrame "Hγfgn". done.
   Qed.
 

--- a/theories/interop/basics.v
+++ b/theories/interop/basics.v
@@ -268,6 +268,11 @@ Inductive repr_lval : addr_map → lval → C_intf.val → Prop :=
     θ !! γ = Some a →
     repr_lval θ (Lloc γ) (C_intf.LitV (C_intf.LitLoc a)).
 
+Inductive repr_lval_out : addr_map → outcome lval → outcome C_intf.val → Prop :=
+  | repr_lval_val θ lv v :
+    repr_lval θ lv v →
+    repr_lval_out θ (OVal lv) (OVal v).
+
 Inductive repr_roots : addr_map → roots_map → memory → Prop :=
   | repr_roots_emp θ :
     repr_roots θ ∅ ∅
@@ -340,6 +345,10 @@ Definition is_store (χ : lloc_map) (ζ : lstore) (σ : store) : Prop :=
     σ !! ℓ = Some (Some vs) → χ !! γ = Some (LlocPublic ℓ) → ζ !! γ = Some blk →
     is_heap_elt χ ζ vs blk.
 
+Inductive is_val_out : lloc_map → lstore → outcome val → outcome lval → Prop :=
+  | is_val_out_val χ ζ v lv:
+    is_val χ ζ v lv →
+    is_val_out χ ζ (OVal v) (OVal lv).
 
 (******************************************************************************)
 (** auxiliary definitions and lemmas *)
@@ -776,6 +785,15 @@ Lemma is_val_mono χ χL ζ ζL x y :
 Proof.
   intros H1 H2; induction 1 in χL,ζL,H1,H2|-*; econstructor; eauto.
   all: eapply lookup_weaken; done.
+Qed.
+
+Lemma is_val_out_mono χ χL ζ ζL x y :
+  χ ⊆ χL → ζ ⊆ ζL →
+  is_val_out χ ζ x y →
+  is_val_out χL ζL x y.
+Proof.
+  intros H1 H2; inversion 1; econstructor; eauto.
+  eapply is_val_mono; eauto.
 Qed.
 
 Lemma is_val_expose_llocs χ χ' ζ v lv :

--- a/theories/interop/basics_constructions.v
+++ b/theories/interop/basics_constructions.v
@@ -235,6 +235,15 @@ Proof.
       eapply map_union_subseteq_r, extended_to_trans; done.
 Qed.
 
+Lemma deserialize_ML_outcome χMLold ov :
+  lloc_map_inj χMLold
+  → ∃ χC ζimm lv,
+    extended_to χMLold ζimm χC
+  ∧ match ov with OVal v => is_val χC ζimm v lv end.
+Proof.
+  destruct ov as [v]; intros Hinj; now apply deserialize_ML_value.
+Qed.
+
 Lemma deserialize_ML_block χMLold vs :
   lloc_map_inj χMLold
 → ∃ χC ζimm blk,
@@ -427,6 +436,22 @@ Qed.
 End ChiZetaConstruction.
 
 Section ThetaConstruction.
+
+Lemma collect_dom_θ_v (θdom : gset lloc) (v : lval) :
+  exists θdom' : gset lloc,
+    ∀ γ, Lloc γ = v ∨ γ ∈ θdom ↔ γ ∈ θdom'.
+Proof.
+  destruct v.
+  - exists θdom. intros γ. split; intros H; last by eauto.
+    destruct H; done.
+  - exists (θdom ∪ {[ n ]}). intros γ. split.
+    + intros [Hc|H]; eapply elem_of_union.
+      1: right; eapply elem_of_singleton; congruence.
+      left; done.
+    + intros [H|H]%elem_of_union.
+      1: by right.
+      left. f_equal. now apply elem_of_singleton in H.
+Qed.
 
 Lemma collect_dom_θ_vs (θdom : gset lloc) (vs : list lval) :
   exists θdom' : gset lloc,

--- a/theories/interop/basics_constructions.v
+++ b/theories/interop/basics_constructions.v
@@ -235,15 +235,6 @@ Proof.
       eapply map_union_subseteq_r, extended_to_trans; done.
 Qed.
 
-Lemma deserialize_ML_outcome χMLold ov :
-  lloc_map_inj χMLold
-  → ∃ χC ζimm lv,
-    extended_to χMLold ζimm χC
-  ∧ match ov with OVal v => is_val χC ζimm v lv end.
-Proof.
-  destruct ov as [v]; intros Hinj; now apply deserialize_ML_value.
-Qed.
-
 Lemma deserialize_ML_block χMLold vs :
   lloc_map_inj χMLold
 → ∃ χC ζimm blk,
@@ -436,22 +427,6 @@ Qed.
 End ChiZetaConstruction.
 
 Section ThetaConstruction.
-
-Lemma collect_dom_θ_v (θdom : gset lloc) (v : lval) :
-  exists θdom' : gset lloc,
-    ∀ γ, Lloc γ = v ∨ γ ∈ θdom ↔ γ ∈ θdom'.
-Proof.
-  destruct v.
-  - exists θdom. intros γ. split; intros H; last by eauto.
-    destruct H; done.
-  - exists (θdom ∪ {[ n ]}). intros γ. split.
-    + intros [Hc|H]; eapply elem_of_union.
-      1: right; eapply elem_of_singleton; congruence.
-      left; done.
-    + intros [H|H]%elem_of_union.
-      1: by right.
-      left. f_equal. now apply elem_of_singleton in H.
-Qed.
 
 Lemma collect_dom_θ_vs (θdom : gset lloc) (vs : list lval) :
   exists θdom' : gset lloc,

--- a/theories/interop/basics_resources.v
+++ b/theories/interop/basics_resources.v
@@ -2,7 +2,7 @@ From Coq Require Import ssreflect.
 From stdpp Require Import strings gmap.
 From transfinite.base_logic.lib Require Import ghost_map ghost_var gen_heap gset_bij.
 From iris.proofmode Require Import proofmode.
-From melocoton Require Import named_props iris_extra.
+From melocoton Require Import language_commons named_props iris_extra.
 From melocoton.ml_lang Require Import lang.
 From melocoton.c_interface Require Import defs.
 From melocoton.interop Require Export basics.
@@ -487,6 +487,18 @@ Proof using.
   induction v as [[x|b| | | |]| | | |] in l|-*; cbn; unshelve eapply (_).
 Qed.
 
+Definition block_sim_out (ov : outcome val) (olv : outcome lval) : iProp Σ :=
+  match ov, olv with
+  | OVal v, OVal lv => block_sim v lv
+  end.
+
+Notation "olv  ~~ₒ  ov" := (block_sim_out ov olv) (at level 20).
+
+Global Instance block_sim_out_pers v l : Persistent (l ~~ₒ v).
+Proof using.
+  destruct v, l. cbn. apply block_sim_pers.
+Qed.
+
 Definition block_sim_arr (vs:list ML_lang.val) (ls : list lval) : iProp Σ :=
   [∗ list] v;l ∈ vs;ls, l ~~ v.
 
@@ -624,6 +636,7 @@ Notation "γ ~ℓ~/" := (lloc_own_priv γ)
   (at level 20, format "γ  ~ℓ~/").
 
 Notation "lv  ~~  v" := (block_sim v lv) (at level 20).
+Notation "olv  ~~ₒ ov" := (block_sim_out ov olv) (at level 20).
 Notation "lvs  ~~∗  vs" := (block_sim_arr vs lvs) (at level 20).
 
 Notation "γ ↦vblk[ a ]{ dq } b" := (lstore_own_vblock γ a dq b)

--- a/theories/interop/lang.v
+++ b/theories/interop/lang.v
@@ -318,7 +318,7 @@ Definition c_to_ml_val
 Definition c_to_ml_outcome
   (ow : outcome word) (ρc : wrapstateC)
   (ov : outcome val) (ρml : wrapstateML) (ζ : lstore)
-: Prop :=
+  : Prop :=
   ∃ olv,
     repr_lval_out (θC ρc) olv ow ∧
     is_val_out (χML ρml) ζ ov olv.

--- a/theories/interop/lang.v
+++ b/theories/interop/lang.v
@@ -140,7 +140,13 @@ Definition ml_to_c_vals
 
 Definition ml_to_c_outcome
   (ov : outcome val) (ow : outcome word) (ρc : wrapstateC) : Prop :=
-  ∃ olv, is_val_out (χC ρc) (ζC ρc) ov olv ∧ repr_lval_out (θC ρc) olv ow.
+  ∃ olv,
+    (** Demonically pick block-level outcome value olv
+        that represent the arguments ov. *)
+    is_val_out (χC ρc) (ζC ρc) ov olv ∧
+    (** Pick C-level outcome words that are live and represent the arguments of
+        the function. (repr_lval on a location entails that it is live.) *)
+    repr_lval_out (θC ρc) olv ow.
 
 Lemma ml_to_c_words_length vs ws ρml :
   ml_to_c_vals vs ws ρml →
@@ -320,7 +326,11 @@ Definition c_to_ml_outcome
   (ov : outcome val) (ρml : wrapstateML) (ζ : lstore)
   : Prop :=
   ∃ olv,
+    (** Angelically pick a block-level outcome value olv that corresponds to the
+      C outcome value ow. *)
     repr_lval_out (θC ρc) olv ow ∧
+    (** Angelically pick an ML outcome value ov that correspond to the
+      block-level outcome value olv. *)
     is_val_out (χML ρml) ζ ov olv.
 
 Local Notation CLocV w := (C_intf.LitV (C_intf.LitLoc w)).

--- a/theories/interop/prims_proto.v
+++ b/theories/interop/prims_proto.v
@@ -25,10 +25,10 @@ Definition wrap_proto (Ψ : ML_proto) : C_proto := (λ f ws Φ,
     "Hproto" ∷ Ψ f vs Φ' ∗
     "Return" ∷ (∀ θ' vret lvret wret,
       GC θ' -∗
-      Φ' (OVal vret) -∗
-      lvret ~~ vret -∗
-      ⌜repr_lval θ' lvret wret⌝ -∗
-      Φ (OVal wret))
+      Φ' vret -∗
+      lvret ~~ₒ vret -∗
+      ⌜repr_lval_out θ' lvret wret⌝ -∗
+      Φ wret)
 )%I.
 
 Lemma wrap_proto_mono Ψ Ψ' : Ψ ⊑ Ψ' → wrap_proto Ψ ⊑ wrap_proto Ψ'.
@@ -183,9 +183,8 @@ Definition callback_proto (Ψ : ML_proto) : C_proto :=
      "WPcallback" ∷ ▷ WP (App (Val (RecV f x e)) (Val v')) at ⟨∅, Ψ⟩ {{ Φ' }}
   }}
     "callback" with [ w; w' ]
-  {{ θ' vret lvret wret, RETV wret;
-     GC θ' ∗ Φ' (OVal vret) ∗ lvret ~~ vret ∗ ⌜repr_lval θ' lvret wret⌝
-  }}.
+  {{ θ' ov olv ow, RET ow;
+     GC θ' ∗ Φ' ov ∗ olv ~~ₒ ov ∗ ⌜repr_lval_out θ' olv ow⌝ }}.
 
 Definition main_proto (Φ' : Z → Prop) (Pinit : iProp Σ) : C_proto :=
   !! {{ "Hat_init" ∷ at_init ∗ "Hinitial_resources" ∷ Pinit }}

--- a/theories/interop/wp_boundary_laws.v
+++ b/theories/interop/wp_boundary_laws.v
@@ -88,7 +88,7 @@ Proof using.
   destruct ov as [v]; iSimpl in "Hblk".
   assert (Forall2 (repr_lval θ) [lv] [w]) by eauto.
   iAssert ([lv] ~~∗ [v]) with "[Hblk]" as "Hls"; first (cbn; iFrame).
-  iDestruct ((wrap_interp_c_to_ml [w] ρc mem θ [v] [lv] H)
+  iDestruct (wrap_interp_c_to_ml [w] ρc mem θ [v] [lv] H
               with "Hσ HGC Hnb Hls") as "(%ρml & %σ & %ζ & %Hheap & %Hlst & H)".
   iExists _, _, _. iFrame. iSplit; eauto.
   iPureIntro. inversion Hlst as (lvs & Hrepr & Hval).
@@ -155,7 +155,7 @@ Proof using.
   iIntros (Hml_to_c H) "Hst Hb".
   destruct ow as [w]. inversion H as (olv & Hrepr & Hval); subst.
   inversion Hval; inversion Hrepr; subst; inversion H8; subst.
-  iDestruct ((wrap_interp_ml_to_c [v0] [lv] ρml σ [w] ρc _) with "Hst Hb")
+  iDestruct (wrap_interp_ml_to_c [v0] [lv] ρml σ [w] ρc mem with "Hst Hb")
          as "> (Hst & Hb & HGC & (Hl & _) & %Hreprs)"; eauto.
   iModIntro. iSplitL "Hst"; eauto. iSplitL "Hb"; eauto.
   iFrame. iExists (OVal lv). iFrame. iPureIntro.

--- a/theories/interop/wp_boundary_laws.v
+++ b/theories/interop/wp_boundary_laws.v
@@ -84,44 +84,16 @@ Lemma wrap_interp_c_to_ml_out ow ρc mem θ ov olv :
   |==> wrap_state_interp (Wrap.MLState ρml σ) ∗ not_at_boundary.
 Proof using.
   iIntros (Hlv) "Hσ HGC Hnb Hblk".
-  iNamed "Hσ". iNamed "SIC". iNamed "HGC". simplify_eq. SI_GC_agree.
-
-  iAssert (⌜∀ k lv, roots_m !! k = Some lv →
-            ∃ w, mem !! k = Some (Storing w) ∧ repr_lval (θC ρc) lv w⌝)%I as "%Hroots".
-  1: { iIntros (kk vv Hroots).
-       iPoseProof (big_sepM_lookup with "GCrootspto") as "(%wr & Hwr & %Hw2)"; first done.
-       iExists wr. iSplit; last done. iApply (gen_heap_valid with "HσC Hwr"). }
-  apply map_Forall_lookup_2 in Hroots.
-  destruct (make_repr (θC ρc) roots_m mem) as [privmem Hpriv]; try done; [].
-
-  iDestruct (hgh_export_ml_heap with "GCHGH")
-    as (ζ' χ' ζfreeze) "(GCHGH & Hσ & %Hχ & %Hfrz & %Hζ)".
-  iAssert (⌜is_val_out χ' ζfreeze ov olv⌝)%I as %Hval.
-  { iDestruct (hgh_block_sim_is_out with "GCHGH Hblk") as %Hval. iPureIntro.
-    eapply (is_val_out_mono χ' χ' ζ'); eauto.
-    by eapply lstore_hybrid_repr_lstore_sub. }
-
-  destruct Hζ as (ζσ&?&?&?&?).
-  (* TODO: refactor opsem to use lstore_hybrid_repr? *)
-  iExists (WrapstateML _ _ _ _), _, _. iSplit. 2: iSplit.
-  { iPureIntro. unfold c_to_ml_outcome. cbn.
-    eexists ζσ. split_and!; eauto;
-    first by rewrite map_union_comm. }
-  { iPureIntro. unfold c_to_ml_outcome. cbn.
-    exists olv. split; eauto. }
-
-  iMod (ghost_var_update_halves with "Hnb SIbound") as "(Hb & SIbound)".
-  iMod (ghost_var_update_halves with "GCζ SIζ") as "(GCζ & SIζ)".
-  iMod (ghost_var_update_halves with "GCχ SIχ") as "(GCχ & SIχ)".
-  iMod (ghost_var_update_halves with "GCθ SIθ") as "(GCθ & SIθ)".
-  iMod (ghost_var_update_halves with "GCroots SIroots") as "(GCroots & SIroots)".
-  iMod (set_to_none with "HσC GCrootspto") as "(HσC & GCrootspto)"; first done.
-
-  iModIntro. iSplitR "SIbound"; last by iFrame "SIbound".
-  rewrite /= /named. iFrame "Hσ".
-  unfold private_state_interp, ML_state_interp, GC_remnant, named; cbn.
-  iFrame. iPureIntro.
-  destruct Hpriv as (mem_r & ->%repr_roots_dom & Hpriv2 & Hpriv3); by apply map_disjoint_dom.
+  destruct ow as [w]. inversion Hlv; subst.
+  destruct ov as [v]; iSimpl in "Hblk".
+  assert (Forall2 (repr_lval θ) [lv] [w]) by eauto.
+  iAssert ([lv] ~~∗ [v]) with "[Hblk]" as "Hls"; first (cbn; iFrame).
+  iDestruct ((wrap_interp_c_to_ml [w] ρc mem θ [v] [lv] H)
+              with "Hσ HGC Hnb Hls") as "(%ρml & %σ & %ζ & %Hheap & %Hlst & H)".
+  iExists _, _, _. iFrame. iSplit; eauto.
+  iPureIntro. inversion Hlst as (lvs & Hrepr & Hval).
+  inversion Hrepr; inversion Hval; subst; inversion H9; subst; exists (OVal x).
+  split; econstructor; eauto.
 Qed.
 
 Lemma wrap_interp_ml_to_c vs lvs ρml σ ws ρc mem :
@@ -181,37 +153,13 @@ Lemma wrap_interp_ml_to_c_out ov ρml σ ow ρc mem :
   (∃ olv, olv ~~ₒ ov ∗ ⌜repr_lval_out (θC ρc) olv ow⌝).
 Proof using.
   iIntros (Hml_to_c H) "Hst Hb".
-  destruct H as (lv & Hval & Hrepre).
-  destruct Hml_to_c as (ζσ & ζnewimm & HH).
-  destruct HH as (Hmono & Hblocks & Hprivblocks & HζC & Hζdisj &
-                    Hstore & ? & ? & Hroots & ?).
-
-  iNamed "Hst". iNamed "SIML". iNamed "SIGCrem".
-  iDestruct (hgh_dom_lstore_sub with "GCHGH") as %Hζsub.
-  iMod (ghost_var_update_halves with "Hb SIbound") as "(Hnb & SIbound)".
-  iMod (ghost_var_update_halves with "SIζ GCζ") as "(SIζ & GCζ)".
-  iMod (ghost_var_update_halves with "SIχ GCχ") as "(SIχ & GCχ)".
-  iMod (ghost_var_update_halves with "SIθ GCθ") as "(SIθ & GCθ)".
-  iMod (ghost_var_update_halves with "SIroots GCroots") as "(SIroots & GCroots)".
-  apply map_disjoint_union_r in Hζdisj as [Hζdisj1 Hζdisj2].
-  iMod (hgh_import_ml_interp _ _ _ _ (ζC ρc) with "GCHGH HσML") as "GCHGH"; eauto.
-  (* TODO: use lstore_hybrid_repr in the opsem? *)
-  { exists ζσ. split_and!; eauto.
-    { rewrite map_union_assoc. rewrite (map_union_comm ζσ); first done. by symmetry. }
-    { apply map_disjoint_union_r; split; eauto.
-      by eapply is_store_blocks_is_private_blocks_disjoint. } }
-  { rewrite HζC !dom_union_L. repeat apply union_least.
-    { destruct Hmono as [?%subseteq_dom ?]. set_solver. }
-    { eapply is_store_blocks_lstore_dom_sub; eauto. }
-    { eapply is_private_blocks_dom_sub; eauto. } }
-  iMod (set_to_some with "HσCv GCrootspto") as "(HσCv & GCrootspto)"; first done.
-  iDestruct (hgh_block_sim_of_out _ _ _ ov lv with "GCHGH") as "#Hsim"; first eassumption.
-
-  iModIntro. iFrame "Hnb". rewrite /= /named.
-  iFrame "HσCv SIζ SIχ SIθ SIroots SIbound".
-  iSplitL "SIinit". { iExists false. iFrame. } iSplit.
-  { rewrite /GC /named. iExists _, _, _, _, _. iFrame. iPureIntro; split_and!; eauto. }
-  { iExists lv. iSplit; eauto. }
+  destruct ow as [w]. inversion H as (olv & Hrepr & Hval); subst.
+  inversion Hval; inversion Hrepr; subst; inversion H8; subst.
+  iDestruct ((wrap_interp_ml_to_c [v0] [lv] ρml σ [w] ρc _) with "Hst Hb")
+         as "> (Hst & Hb & HGC & (Hl & _) & %Hreprs)"; eauto.
+  iModIntro. iSplitL "Hst"; eauto. iSplitL "Hb"; eauto.
+  iFrame. iExists (OVal lv). iFrame. iPureIntro.
+  econstructor. inversion Hreprs; eauto.
 Qed.
 
 End BoundaryLaws.

--- a/theories/interop/wp_boundary_laws.v
+++ b/theories/interop/wp_boundary_laws.v
@@ -47,7 +47,7 @@ Proof using.
   iDestruct (hgh_export_ml_heap with "GCHGH")
     as (ζ' χ' ζfreeze) "(GCHGH & Hσ & %Hχ & %Hfrz & %Hζ)".
   iAssert (⌜Forall2 (is_val χ' ζfreeze) vs lvs⌝)%I as %Hval.
-  { iDestruct (hgh_block_sim_is_val with "GCHGH Hblk") as %Hval. iPureIntro.
+  { iDestruct (hgh_block_sim_is_vals with "GCHGH Hblk") as %Hval. iPureIntro.
     eapply Forall2_impl; first done. intros ? ?. eapply is_val_mono; eauto.
     by eapply lstore_hybrid_repr_lstore_sub. }
 
@@ -57,6 +57,58 @@ Proof using.
   { iPureIntro. unfold c_to_ml_heap. cbn.
     eexists ζσ. split_and!; eauto. by rewrite map_union_comm. }
   { iPureIntro. unfold c_to_ml_vals. cbn. exists lvs. split_and!; eauto. }
+
+  iMod (ghost_var_update_halves with "Hnb SIbound") as "(Hb & SIbound)".
+  iMod (ghost_var_update_halves with "GCζ SIζ") as "(GCζ & SIζ)".
+  iMod (ghost_var_update_halves with "GCχ SIχ") as "(GCχ & SIχ)".
+  iMod (ghost_var_update_halves with "GCθ SIθ") as "(GCθ & SIθ)".
+  iMod (ghost_var_update_halves with "GCroots SIroots") as "(GCroots & SIroots)".
+  iMod (set_to_none with "HσC GCrootspto") as "(HσC & GCrootspto)"; first done.
+
+  iModIntro. iSplitR "SIbound"; last by iFrame "SIbound".
+  rewrite /= /named. iFrame "Hσ".
+  unfold private_state_interp, ML_state_interp, GC_remnant, named; cbn.
+  iFrame. iPureIntro.
+  destruct Hpriv as (mem_r & ->%repr_roots_dom & Hpriv2 & Hpriv3); by apply map_disjoint_dom.
+Qed.
+
+Lemma wrap_interp_c_to_ml_out ow ρc mem θ ov olv :
+  repr_lval_out θ olv ow →
+  wrap_state_interp (Wrap.CState ρc mem) -∗
+  GC θ -∗
+  at_boundary wrap_lang -∗
+  olv ~~ₒ ov -∗
+  ∃ ρml σ ζ,
+  ⌜c_to_ml_heap ρc mem ρml σ ζ⌝ ∗
+  ⌜c_to_ml_outcome ow ρc ov ρml ζ⌝ ∗
+  |==> wrap_state_interp (Wrap.MLState ρml σ) ∗ not_at_boundary.
+Proof using.
+  iIntros (Hlv) "Hσ HGC Hnb Hblk".
+  iNamed "Hσ". iNamed "SIC". iNamed "HGC". simplify_eq. SI_GC_agree.
+
+  iAssert (⌜∀ k lv, roots_m !! k = Some lv →
+            ∃ w, mem !! k = Some (Storing w) ∧ repr_lval (θC ρc) lv w⌝)%I as "%Hroots".
+  1: { iIntros (kk vv Hroots).
+       iPoseProof (big_sepM_lookup with "GCrootspto") as "(%wr & Hwr & %Hw2)"; first done.
+       iExists wr. iSplit; last done. iApply (gen_heap_valid with "HσC Hwr"). }
+  apply map_Forall_lookup_2 in Hroots.
+  destruct (make_repr (θC ρc) roots_m mem) as [privmem Hpriv]; try done; [].
+
+  iDestruct (hgh_export_ml_heap with "GCHGH")
+    as (ζ' χ' ζfreeze) "(GCHGH & Hσ & %Hχ & %Hfrz & %Hζ)".
+  iAssert (⌜is_val_out χ' ζfreeze ov olv⌝)%I as %Hval.
+  { iDestruct (hgh_block_sim_is_out with "GCHGH Hblk") as %Hval. iPureIntro.
+    eapply (is_val_out_mono χ' χ' ζ'); eauto.
+    by eapply lstore_hybrid_repr_lstore_sub. }
+
+  destruct Hζ as (ζσ&?&?&?&?).
+  (* TODO: refactor opsem to use lstore_hybrid_repr? *)
+  iExists (WrapstateML _ _ _ _), _, _. iSplit. 2: iSplit.
+  { iPureIntro. unfold c_to_ml_outcome. cbn.
+    eexists ζσ. split_and!; eauto;
+    first by rewrite map_union_comm. }
+  { iPureIntro. unfold c_to_ml_outcome. cbn.
+    exists olv. split; eauto. }
 
   iMod (ghost_var_update_halves with "Hnb SIbound") as "(Hb & SIbound)".
   iMod (ghost_var_update_halves with "GCζ SIζ") as "(GCζ & SIζ)".
@@ -108,13 +160,58 @@ Proof using.
     { eapply is_store_blocks_lstore_dom_sub; eauto. }
     { eapply is_private_blocks_dom_sub; eauto. } }
   iMod (set_to_some with "HσCv GCrootspto") as "(HσCv & GCrootspto)"; first done.
-  iDestruct (hgh_block_sim_of _ _ _ vs lvs with "GCHGH") as "#Hsim"; first eassumption.
+  iDestruct (hgh_block_sim_of_vals _ _ _ vs lvs with "GCHGH") as "#Hsim"; first eassumption.
 
   iModIntro. iFrame "Hnb". rewrite /= /named.
   iFrame "HσCv SIζ SIχ SIθ SIroots SIbound".
   iSplitL "SIinit". { iExists false. iFrame. } iSplit.
   { rewrite /GC /named. iExists _, _, _, _, _. iFrame. iPureIntro; split_and!; eauto. }
   { by iFrame "Hsim". }
+Qed.
+
+Lemma wrap_interp_ml_to_c_out ov ρml σ ow ρc mem :
+  ml_to_c_heap ρml σ ρc mem →
+  ml_to_c_outcome ov ow ρc →
+  wrap_state_interp (Wrap.MLState ρml σ) -∗
+  not_at_boundary
+  ==∗
+  wrap_state_interp (Wrap.CState ρc mem) ∗
+  at_boundary wrap_lang ∗
+  GC (θC ρc) ∗
+  (∃ olv, olv ~~ₒ ov ∗ ⌜repr_lval_out (θC ρc) olv ow⌝).
+Proof using.
+  iIntros (Hml_to_c H) "Hst Hb".
+  destruct H as (lv & Hval & Hrepre).
+  destruct Hml_to_c as (ζσ & ζnewimm & HH).
+  destruct HH as (Hmono & Hblocks & Hprivblocks & HζC & Hζdisj &
+                    Hstore & ? & ? & Hroots & ?).
+
+  iNamed "Hst". iNamed "SIML". iNamed "SIGCrem".
+  iDestruct (hgh_dom_lstore_sub with "GCHGH") as %Hζsub.
+  iMod (ghost_var_update_halves with "Hb SIbound") as "(Hnb & SIbound)".
+  iMod (ghost_var_update_halves with "SIζ GCζ") as "(SIζ & GCζ)".
+  iMod (ghost_var_update_halves with "SIχ GCχ") as "(SIχ & GCχ)".
+  iMod (ghost_var_update_halves with "SIθ GCθ") as "(SIθ & GCθ)".
+  iMod (ghost_var_update_halves with "SIroots GCroots") as "(SIroots & GCroots)".
+  apply map_disjoint_union_r in Hζdisj as [Hζdisj1 Hζdisj2].
+  iMod (hgh_import_ml_interp _ _ _ _ (ζC ρc) with "GCHGH HσML") as "GCHGH"; eauto.
+  (* TODO: use lstore_hybrid_repr in the opsem? *)
+  { exists ζσ. split_and!; eauto.
+    { rewrite map_union_assoc. rewrite (map_union_comm ζσ); first done. by symmetry. }
+    { apply map_disjoint_union_r; split; eauto.
+      by eapply is_store_blocks_is_private_blocks_disjoint. } }
+  { rewrite HζC !dom_union_L. repeat apply union_least.
+    { destruct Hmono as [?%subseteq_dom ?]. set_solver. }
+    { eapply is_store_blocks_lstore_dom_sub; eauto. }
+    { eapply is_private_blocks_dom_sub; eauto. } }
+  iMod (set_to_some with "HσCv GCrootspto") as "(HσCv & GCrootspto)"; first done.
+  iDestruct (hgh_block_sim_of_out _ _ _ ov lv with "GCHGH") as "#Hsim"; first eassumption.
+
+  iModIntro. iFrame "Hnb". rewrite /= /named.
+  iFrame "HσCv SIζ SIχ SIθ SIroots SIbound".
+  iSplitL "SIinit". { iExists false. iFrame. } iSplit.
+  { rewrite /GC /named. iExists _, _, _, _, _. iFrame. iPureIntro; split_and!; eauto. }
+  { iExists lv. iSplit; eauto. }
 Qed.
 
 End BoundaryLaws.

--- a/theories/interop/wp_prims/alloc.v
+++ b/theories/interop/wp_prims/alloc.v
@@ -49,7 +49,7 @@ Proof using.
     repr θC' roots_m privmem mem' ∧
     roots_are_live θC' roots_m ∧
     θC' !! γ = Some a ∧
-    e' = WrSE (ExprV #a) ∧
+    e' = WrSE (ExprO (OVal #a)) ∧
     σ' = CState {| χC := χC'; ζC := ζC'; θC := θC'; rootsC := rootsC ρc |} mem').
   iSplit. { iPureIntro. econstructor; naive_solver. }
   iIntros (? ? ? (γ & χC' & ζC' & θC' & a & mem' &

--- a/theories/interop/wp_prims/alloc_foreign.v
+++ b/theories/interop/wp_prims/alloc_foreign.v
@@ -48,7 +48,7 @@ Proof using.
       repr θC' roots_m privmem mem' ∧
       roots_are_live θC' roots_m ∧
       θC' !! γ = Some aret ∧
-      e' = WrSE (ExprV (# aret)) ∧
+      e' = WrSE (ExprO (OVal (# aret))) ∧
       σ' = CState (WrapstateC χC' ζC' θC' (rootsC ρc)) mem').
   iSplit. { iPureIntro. econstructor; naive_solver. }
   iIntros (? ? ? (γ & χC' & ζC' & θC' & aret & mem' &

--- a/theories/interop/wp_prims/common.v
+++ b/theories/interop/wp_prims/common.v
@@ -42,11 +42,11 @@ Lemma wp_pre_cases_c_prim p T wp prm ρc mem E ws Φ :
   prm ≠ Pcallback →
   (∀ e, prm ≠ Pmain e) →
   (∃ X,
-    ⌜c_prim_step prm ws ρc mem (λ w ρc' mem', X (WrSE (ExprV w), CState ρc' mem'))⌝ ∗
+    ⌜c_prim_step prm ws ρc mem (λ w ρc' mem', X (WrSE (ExprO (OVal w)), CState ρc' mem'))⌝ ∗
     (∀ w ρc' mem',
-       ⌜X (WrSE (ExprV w), CState ρc' mem')⌝ ={E}▷=∗
+       ⌜X (WrSE (ExprO (OVal w)), CState ρc' mem')⌝ ={E}▷=∗
        weakestpre.state_interp (CState ρc' mem') ∗
-       wp E (WrSE (ExprV w)) Φ)) -∗
+       wp E (WrSE (ExprO (OVal w))) Φ)) -∗
   |={E}=> wp_pre_cases p T wp (CState ρc mem) E
     (WrSE (RunPrimitive prm ws))
     Φ.
@@ -56,7 +56,7 @@ Proof using.
   iSplit; first done.
   iDestruct "HWP" as (X Hpstep) "HWP".
   iExists (λ '(e', σ'), X (e', σ') ∧ ∃ w ρc' mem',
-            e' = WrSE (ExprV w) ∧ σ' = CState ρc' mem').
+            e' = WrSE (ExprO (OVal w)) ∧ σ' = CState ρc' mem').
   iSplit.
   { iPureIntro. econstructor.
     eapply c_prim_step_covariant_in_Y; naive_solver. }

--- a/theories/interop/wp_prims/int2val.v
+++ b/theories/interop/wp_prims/int2val.v
@@ -28,7 +28,7 @@ Proof using.
   SI_at_boundary. iNamed "HGC". SI_GC_agree.
 
   iApply wp_pre_cases_c_prim; [done..|].
-  iExists (λ '(e', σ'), e' = WrSE (ExprV (code_int z)) ∧ σ' = CState ρc mem).
+  iExists (λ '(e', σ'), e' = WrSE (ExprO (OVal (code_int z))) ∧ σ' = CState ρc mem).
   iSplit. { iPureIntro. econstructor; eauto. }
   iIntros (? ? ? (? & ?)); simplify_eq.
   do 3 iModIntro. iFrame. iSplitL "SIinit". { iExists false. iFrame. }

--- a/theories/interop/wp_prims/isblock.v
+++ b/theories/interop/wp_prims/isblock.v
@@ -30,7 +30,7 @@ Proof using.
   SI_at_boundary. iNamed "HGC". SI_GC_agree.
 
   iApply wp_pre_cases_c_prim; [done..|].
-  iExists (λ '(e', σ'), e' = WrSE (ExprV #(match lv with  Lint _ => 0 | Lloc _ => 1 end)) ∧ σ' = CState ρc mem).
+  iExists (λ '(e', σ'), e' = WrSE (ExprO (OVal #(match lv with  Lint _ => 0 | Lloc _ => 1 end))) ∧ σ' = CState ρc mem).
   iSplit. { iPureIntro; edestruct lv; try (econstructor; eauto; fail). }
   iIntros (? ? ? (? & ?)); simplify_eq.
   do 3 iModIntro. iFrame. iSplitL "SIinit". { iExists false. iFrame. }

--- a/theories/interop/wp_prims/length.v
+++ b/theories/interop/wp_prims/length.v
@@ -35,7 +35,7 @@ Proof using.
   destruct Helem2 as [m' Helem2].
 
   iApply wp_pre_cases_c_prim; [done..|].
-  iExists (λ '(e', σ'), e' = WrSE (ExprV #(length vs0)) ∧ σ' = CState ρc mem).
+  iExists (λ '(e', σ'), e' = WrSE (ExprO (OVal #(length vs0))) ∧ σ' = CState ρc mem).
   iSplit. { iPureIntro; econstructor; eauto. }
   iIntros (? ? ? (? & ?)); simplify_eq.
   do 3 iModIntro. iFrame. iSplitL "SIinit". { iExists false. iFrame. }

--- a/theories/interop/wp_prims/modify.v
+++ b/theories/interop/wp_prims/modify.v
@@ -39,7 +39,7 @@ Proof using.
     by (constructor; lia).
 
   iExists (λ '(e', σ'),
-    e' = WrSE (ExprV #0) ∧
+    e' = WrSE (ExprO (OVal #0)) ∧
     σ' = CState {| χC := χC ρc; ζC := <[γ:=blk']> (ζC ρc); θC := θC ρc; rootsC := rootsC ρc |} mem).
   iSplit. { iPureIntro; econstructor; eauto. }
   iIntros (? ? ? (? & ?)); simplify_eq.

--- a/theories/interop/wp_prims/read_foreign.v
+++ b/theories/interop/wp_prims/read_foreign.v
@@ -35,7 +35,7 @@ Proof using.
   }
   destruct Helem2 as [m' Helem2].
   iApply wp_pre_cases_c_prim; [done..|].
-  iExists (λ '(e', σ'), e' = WrSE (ExprV w') ∧ σ' = CState ρc mem).
+  iExists (λ '(e', σ'), e' = WrSE (ExprO (OVal w')) ∧ σ' = CState ρc mem).
   iSplit. { iPureIntro; econstructor; eauto. }
   iIntros (? ? ? (? & ?)); simplify_eq.
   do 3 iModIntro. iFrame. iSplitL "SIinit". { iExists false. iFrame. }

--- a/theories/interop/wp_prims/read_tag.v
+++ b/theories/interop/wp_prims/read_tag.v
@@ -33,7 +33,7 @@ Proof using.
     inversion Hb; subst; eauto. }
 
   iApply wp_pre_cases_c_prim; [done..|].
-  iExists (λ '(e', σ'), e' = WrSE (ExprV #(tag_as_int (block_tag _))) ∧ σ' = CState ρc mem).
+  iExists (λ '(e', σ'), e' = WrSE (ExprO (OVal #(tag_as_int (block_tag _)))) ∧ σ' = CState ρc mem).
   iSplit. { iPureIntro; econstructor; eauto. }
   iIntros (? ? ? (? & ?)); simplify_eq.
   do 3 iModIntro. iFrame. iSplitL "SIinit". { iExists false. iFrame. }

--- a/theories/interop/wp_prims/readfield.v
+++ b/theories/interop/wp_prims/readfield.v
@@ -42,7 +42,7 @@ Proof using.
        2: constructor; by eapply elem_of_list_lookup_2. eauto. }
 
   iApply wp_pre_cases_c_prim; [done..|].
-  iExists (λ '(e', σ'), e' = WrSE (ExprV w') ∧ σ' = CState ρc mem).
+  iExists (λ '(e', σ'), e' = WrSE (ExprO (OVal w')) ∧ σ' = CState ρc mem).
   iSplit. { iPureIntro; econstructor; eauto. }
   iIntros (? ? ? (? & ?)); simplify_eq.
   do 3 iModIntro. iFrame. iSplitL "SIinit". { iExists false. iFrame. }

--- a/theories/interop/wp_prims/registerroot.v
+++ b/theories/interop/wp_prims/registerroot.v
@@ -35,7 +35,7 @@ Proof using.
 
   iApply wp_pre_cases_c_prim; [done..|].
   iExists (λ '(e', σ'),
-    e' = WrSE (ExprV #0) ∧
+    e' = WrSE (ExprO (OVal #0)) ∧
     σ' = CState {| χC := χC ρc; ζC := ζC ρc; θC := θC ρc; rootsC := {[l]} ∪ rootsC ρc |} mem).
   iSplit. { iPureIntro. econstructor; eauto. congruence. }
   iIntros (w' ρc' mem' (? & ?)); simplify_eq.

--- a/theories/interop/wp_prims/unregisterroot.v
+++ b/theories/interop/wp_prims/unregisterroot.v
@@ -32,7 +32,7 @@ Proof using.
 
   iApply wp_pre_cases_c_prim; [done..|].
   iExists (λ '(e', σ'),
-    e' = WrSE (ExprV #0) ∧
+    e' = WrSE (ExprO (OVal #0)) ∧
     σ' = CState {| χC := χC ρc; ζC := ζC ρc; θC := θC ρc; rootsC := rootsC ρc ∖ {[l]} |} mem).
   iSplit. { iPureIntro. econstructor; eauto. rewrite -H2. by eapply elem_of_dom_2. }
   iIntros (? ? ? (? & ?)); simplify_eq.

--- a/theories/interop/wp_prims/val2int.v
+++ b/theories/interop/wp_prims/val2int.v
@@ -29,7 +29,7 @@ Proof using.
   SI_at_boundary. iNamed "HGC". SI_GC_agree.
 
   iApply wp_pre_cases_c_prim; [done..|].
-  iExists (λ '(e', σ'), e' = WrSE (ExprV #z) ∧ σ' = CState ρc mem).
+  iExists (λ '(e', σ'), e' = WrSE (ExprO (OVal #z)) ∧ σ' = CState ρc mem).
   iSplit. { iPureIntro. econstructor; eauto. }
   iIntros (? ? ? (? & ?)); simplify_eq.
   do 3 iModIntro.

--- a/theories/interop/wp_prims/write_foreign.v
+++ b/theories/interop/wp_prims/write_foreign.v
@@ -35,7 +35,7 @@ Proof using.
 
   iApply wp_pre_cases_c_prim; [done..|].
   iExists (λ '(e', σ'),
-    e' = WrSE (ExprV #0) ∧
+    e' = WrSE (ExprO (OVal #0)) ∧
     σ' = CState (WrapstateC (χC ρc) (<[γ:=Bforeign (Mut, Some w')]> (ζC ρc)) (θC ρc) (rootsC ρc)) mem).
   iSplit. { iPureIntro; econstructor; eauto. }
   iIntros (? ? ? (? & ?)); simplify_eq.

--- a/theories/interop/wp_simulation.v
+++ b/theories/interop/wp_simulation.v
@@ -25,10 +25,10 @@ Context `{!wrapperG Σ}.
 Implicit Types P : iProp Σ.
 Import mlanguage.
 
-Lemma wp_to_val (pe : progenv.prog_environ wrap_lang Σ) v:
-    not_at_boundary
- -∗ WP (WrSE (ExprML (ML_lang.Val v))) at pe {{ o,
-      ∃ θ' w lv, ⌜OVal w = o⌝ ∗ GC θ' ∗ ⌜repr_lval θ' lv w⌝ ∗ lv ~~ v ∗
+Lemma wp_to_outcome (pe : progenv.prog_environ wrap_lang Σ) (o : outcome MLval):
+  not_at_boundary
+ -∗ WP (WrSE (ExprML (language.of_outcome ML_lang o))) at pe {{ ret,
+   ∃ θ' ov olv, ⌜o = ov⌝ ∗ GC θ' ∗ ⌜repr_lval_out θ' olv ret⌝ ∗ olv ~~ₒ ov ∗
       at_boundary wrap_lang }}.
 Proof using.
   iIntros "Hnb".
@@ -45,24 +45,21 @@ Proof using.
     iDestruct (hgh_χ_inj with "GCHGH") as %?.
     iPureIntro; split_and!; eauto. }
 
-  iExists (λ '(e', σ'), ∃ w ρc mem,
+  iExists (λ '(e', σ'), ∃ ow ρc mem,
     ml_to_c_heap ρml σ ρc mem ∧
-    ml_to_c_outcome (OVal v) (OVal w) ρc ∧
-    e' = WrSE (ExprO (OVal w)) ∧ σ' = CState ρc mem).
-  iSplit. { iPureIntro. eapply OutS; try naive_solver.
-    intros * Hp (lv & Hval & Hrepr). inversion Hval; subst.
-    inversion Hrepr; subst. exists v0, ρc, mem.
-    split_and!; try naive_solver. unfold ml_to_c_outcome. now exists (OVal lv0). }
+    ml_to_c_outcome o ow ρc ∧
+    e' = WrSE (ExprO (ow)) ∧ σ' = CState ρc mem).
+  iSplit.
+  { iPureIntro. eapply OutS; try naive_solver.
+    apply language.to_of_outcome. }
 
   iIntros (? ? (w & ρc & mem & Hout & Hrepr & -> & ->)).
   iMod (wrap_interp_ml_to_c_out with "SI Hnb") as "(SI & Hb & HGC & H)";
     first done; first done.
   do 3 iModIntro. iFrame "SI".
-  replace (WrSE (ExprO (OVal w))) with (of_outcome wrap_lang (OVal w)) by done.
   iApply weakestpre.wp_outcome'.
   iDestruct "H" as "(% & Hls & %Hval)".
-  inversion Hval; subst.
-  iExists _, w, lv. iFrame. repeat iSplit; eauto.
+  iExists _, o, olv. iFrame. repeat iSplit; eauto.
 Qed.
 
 Lemma wp_simulates (Ψ : protocol ML_lang.val Σ) eml emain Φ :
@@ -70,7 +67,7 @@ Lemma wp_simulates (Ψ : protocol ML_lang.val Σ) eml emain Φ :
   not_at_boundary -∗
   WP eml at ⟨ ∅, Ψ ⟩ {{ Φ }} -∗
   WP (WrSE (ExprML eml)) at ⟪ wrap_prog emain, wrap_proto Ψ ⟫ {{ o,
-    ∃ θ' w lv v, ⌜OVal w = o⌝ ∗ GC θ' ∗ ⌜repr_lval θ' lv w⌝ ∗ lv ~~ v ∗ Φ (OVal v) ∗
+    ∃ θ' ov olv, GC θ' ∗ ⌜repr_lval_out θ' olv o⌝ ∗ olv ~~ₒ ov ∗ Φ ov ∗
     at_boundary wrap_lang }}.
 Proof.
   intros Hnprims.
@@ -84,13 +81,12 @@ Proof.
   iMod ("HWP" $! σ with "[$HσML]") as "[HWP|[HWP|HWP]]".
   (* value *)
   + iDestruct "HWP" as "(%o & -> & Hσ & Hret)".
-    destruct o.
-    iPoseProof (wp_to_val _ v with "Hnb") as "Hwp".
+    iPoseProof (wp_to_outcome _ o with "Hnb") as "Hwp".
     iDestruct (weakestpre.wp_strong_mono_post with "[Hret] Hwp") as "Hwp";
       last first.
     { rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre.
       iApply ("Hwp" $! (MLState ρml σ)). iFrame. by iPureIntro. }
-    { cbn. iIntros (vv) "(%θ' & %w & %lv & ? & ? & ? & ? & ?)". iExists _, _, _, _. iFrame. }
+    { cbn. iIntros (vv) "(%θ' & %w & %lv & -> & ? & ? & ? & ?)". iExists _, _, _. iFrame. }
   (* extcall *)
   + iDestruct "HWP" as "(%fn_name & %vs & %K' & -> & %Hfn & >(%Ξ & Hσ & HT & Hr))".
     iAssert (⌜¬ is_prim_name fn_name⌝)%I with "[HT]" as "%Hnprim".
@@ -136,12 +132,12 @@ Proof.
     { iPureIntro. apply not_elem_of_dom.
       rewrite dom_wrap_prog not_elem_of_prim_names //. }
     iFrame "Hb Hst'".
-    iExists (λ o, ∃ θ' wret vret lvret, ⌜OVal wret = o⌝ ∗ GC θ' ∗ Ξ (OVal vret) ∗ lvret ~~ vret ∗ ⌜repr_lval θ' lvret wret⌝)%I.
+    iExists (λ o, ∃ θ' wret vret lvret, ⌜o = wret⌝ ∗ GC θ' ∗ Ξ vret ∗ lvret ~~ₒ vret ∗ ⌜repr_lval_out θ' lvret wret⌝)%I.
     iSplitL "HGC HT".
     { rewrite /wrap_proto /named /=. iExists _, _, _, _.
       iFrame "HGC HT Hblk". iSplit; first done.
-      iIntros (? ? ? ?) "? ? ? %". iExists _, _, _, _. by iFrame. }
-    iNext. iIntros (o) "((%θ' & %wret & %vret & %lvret & <- & HGC & HΞ & Hsim & %) & Hb)".
+      iIntros (? ? ? ?) "? ? ? %". iExists _, _, _, _. iFrame. iPureIntro. eauto. }
+    iNext. iIntros (o) "((%θ' & %wret & %vret & %lvret & -> & HGC & HΞ & Hsim & %) & Hb)".
 
     (* extcall done; take an administrative step for the call return *)
 
@@ -150,12 +146,10 @@ Proof.
     iDestruct (SI_at_boundary_is_in_C with "Hst' Hb") as %(ρc'&mem'&->). simpl.
     iRight; iRight. iSplit; first done.
 
-    iDestruct ((wrap_interp_c_to_ml_out (OVal wret) _ _ _ (OVal vret) (OVal lvret)) with "Hst' HGC Hb [Hsim]")
-      as (ρml' σ' ζ Hc_to_ml_heap Hc_to_ml_out) "HH".
-    { constructor. eauto. }
-    { cbn. iFrame. }
+    iDestruct ((wrap_interp_c_to_ml_out wret _ _ _ vret lvret) with "Hst' HGC Hb [Hsim]")
+      as (ρml' σ' ζ Hc_to_ml_heap Hc_to_ml_out) "HH"; eauto.
     iExists (λ '(e2, σ2),
-      e2 = WrSE (ExprML (language.fill K' (Val vret))) ∧
+      e2 = WrSE (ExprML (language.fill K' (lang.ML_lang.of_outcome vret))) ∧
       σ2 = MLState ρml' σ').
     iSplit.
     { iPureIntro. eapply RetS; eauto. }
@@ -165,7 +159,6 @@ Proof.
     (* continue execution using IH *)
 
     iApply ("IH" with "Hnb").
-    replace (Val vret) with (lang.ML_lang.of_outcome (OVal vret)) by done.
     by iApply "Hr".
 
   (* step *)
@@ -224,7 +217,7 @@ Proof using.
   do 3 iModIntro. iFrame "Hst".
   iApply (weakestpre.wp_wand with "[-Cont Hcont Hclos]").
   { by iApply (wp_simulates with "Hnb [WPcallback]"). }
-  cbn. iIntros (o) "(%θ' & %wr & %lv & %vret & <- & HGC & % & Hsim & Hψ & ?)".
+  cbn. iIntros (o) "(%θ' & %lv & %vret & HGC & % & Hsim & Hψ & ?)".
   iApply "Hcont". iFrame.
   iApply "Cont". iFrame; eauto.
 Qed.
@@ -273,10 +266,13 @@ Proof using.
   iApply (weakestpre.wp_wand with "[-Cont Hcont]").
   { iApply (wp_simulates with "Hb [Hinitial_resources]"); first done.
     iApply (Hmain with "[$]"). }
-  cbn. iIntros (o) "(%θ' & %v & %lv & %vret & <- & HGC & %Hrepr & Hsim & HΦ' & ?)".
+  cbn. iIntros (o) "(%θ' & %v & %lv & HGC & %Hrepr & Hsim & HΦ' & ?)".
   iDestruct "HΦ'" as (?) "[%Hv %HΦ]". inversion Hv. subst.
-  iDestruct "Hsim" as "->". inversion Hrepr; simplify_eq.
-  iApply "Hcont". iFrame. by iApply "Cont".
+  destruct lv.
+  { iDestruct "Hsim" as "->". inversion Hrepr; simplify_eq.
+    inversion H2; simplify_eq.
+    iApply "Hcont". iFrame. by iApply "Cont".
+  }
 Qed.
 
 Lemma wrap_correct emain Ψ (Φ : Z → Prop) P :

--- a/theories/interop/wp_simulation.v
+++ b/theories/interop/wp_simulation.v
@@ -53,13 +53,12 @@ Proof using.
   { iPureIntro. eapply OutS; try naive_solver.
     apply language.to_of_outcome. }
 
-  iIntros (? ? (w & ρc & mem & Hout & Hrepr & -> & ->)).
-  iMod (wrap_interp_ml_to_c_out with "SI Hnb") as "(SI & Hb & HGC & H)";
+  iIntros (? ? (w & ρc & mem & Hout & Hcore & -> & ->)).
+  iMod (wrap_interp_ml_to_c_out with "SI Hnb") as "(SI & Hb & HGC & (%ov & Hbo & %Hrepr))";
     first done; first done.
   do 3 iModIntro. iFrame "SI".
   iApply weakestpre.wp_outcome'.
-  iDestruct "H" as "(% & Hls & %Hval)".
-  iExists _, olv. iFrame. repeat iSplit; eauto.
+  iExists _, _. iFrame. by inversion Hrepr; simplify_eq.
 Qed.
 
 Lemma wp_simulates (Ψ : protocol ML_lang.val Σ) eml emain Φ :
@@ -149,6 +148,7 @@ Proof.
 
     iDestruct ((wrap_interp_c_to_ml_out wret _ _ _ vret lvret) with "Hst' HGC Hb [Hsim]")
       as (ρml' σ' ζ Hc_to_ml_heap Hc_to_ml_out) "HH"; eauto.
+
     iExists (λ '(e2, σ2),
       e2 = WrSE (ExprML (language.fill K' (lang.ML_lang.of_outcome vret))) ∧
       σ2 = MLState ρml' σ').

--- a/theories/interop/wp_simulation.v
+++ b/theories/interop/wp_simulation.v
@@ -28,7 +28,7 @@ Import mlanguage.
 Lemma wp_to_outcome (pe : progenv.prog_environ wrap_lang Σ) (o : outcome MLval):
   not_at_boundary
  -∗ WP (WrSE (ExprML (language.of_outcome ML_lang o))) at pe {{ ret,
-   ∃ θ' ov olv, ⌜o = ov⌝ ∗ GC θ' ∗ ⌜repr_lval_out θ' olv ret⌝ ∗ olv ~~ₒ ov ∗
+   ∃ θ' olv, GC θ' ∗ ⌜repr_lval_out θ' olv ret⌝ ∗ olv ~~ₒ o ∗
       at_boundary wrap_lang }}.
 Proof using.
   iIntros "Hnb".
@@ -59,7 +59,7 @@ Proof using.
   do 3 iModIntro. iFrame "SI".
   iApply weakestpre.wp_outcome'.
   iDestruct "H" as "(% & Hls & %Hval)".
-  iExists _, o, olv. iFrame. repeat iSplit; eauto.
+  iExists _, olv. iFrame. repeat iSplit; eauto.
 Qed.
 
 Lemma wp_simulates (Ψ : protocol ML_lang.val Σ) eml emain Φ :
@@ -86,7 +86,8 @@ Proof.
       last first.
     { rewrite weakestpre.wp_unfold. rewrite /weakestpre.wp_pre.
       iApply ("Hwp" $! (MLState ρml σ)). iFrame. by iPureIntro. }
-    { cbn. iIntros (vv) "(%θ' & %w & %lv & -> & ? & ? & ? & ?)". iExists _, _, _. iFrame. }
+    { cbn. iIntros (vv) "(%θ' & %olv & HGC & %Hrep & Hval & ?)".
+      iExists _, _, _. iFrame. eauto. }
   (* extcall *)
   + iDestruct "HWP" as "(%fn_name & %vs & %K' & -> & %Hfn & >(%Ξ & Hσ & HT & Hr))".
     iAssert (⌜¬ is_prim_name fn_name⌝)%I with "[HT]" as "%Hnprim".


### PR DESCRIPTION
Replace value with outcome in `interop` language.
Generalize `callback`, `wp_simulate`
Add `wrap_interp_c_to_ml_out` and `wrap_interp_ml_to_c_out`